### PR TITLE
Fix: 잘못된 interface 상속 수정

### DIFF
--- a/frontend/_packages/@external-temporal/components/molecule/Filter/Filter.tsx
+++ b/frontend/_packages/@external-temporal/components/molecule/Filter/Filter.tsx
@@ -1,11 +1,11 @@
-import React, { HTMLAttributes } from "react";
-import { Icon } from "#/components/atom/Icon/Icon";
-import { Input } from "#/components/atom/Input/Input";
-import { Label } from "#/components/atom/Label/Label";
-import { H5 } from "#/components/atom/Hn/H5";
-import { STATUS } from "./Filter.css";
+import { HTMLAttributes } from 'react';
+import { Icon } from '#/components/atom/Icon/Icon';
+import { Input } from '#/components/atom/Input/Input';
+import { Label } from '#/components/atom/Label/Label';
+import { H5 } from '#/components/atom/Hn/H5';
+import { STATUS } from './Filter.css';
 
-export interface FilterProps extends HTMLAttributes<HTMLSelectElement> {
+export interface FilterProps {
   isOpen: boolean;
   onClick?(e: React.MouseEvent): void;
   main: string;
@@ -21,10 +21,10 @@ export interface OptionProps {
 }
 
 export function Filter({ isOpen, onClick, main, children }: FilterProps) {
-  const iconType = isOpen ? "up" : "down";
-  const status = isOpen ? "open" : "close";
-  const mainStatus = isOpen ? "openMain" : "closeMain";
-  const optionStatus = isOpen ? "openOptions" : "closeOptions";
+  const iconType = isOpen ? 'up' : 'down';
+  const status = isOpen ? 'open' : 'close';
+  const mainStatus = isOpen ? 'openMain' : 'closeMain';
+  const optionStatus = isOpen ? 'openOptions' : 'closeOptions';
   return (
     <div className={STATUS[status]}>
       <div className={STATUS[mainStatus]} onClick={onClick}>
@@ -44,7 +44,7 @@ Filter.FilterOption = function FilterOption({
   children,
 }: OptionProps) {
   return (
-    <li className={STATUS["option"]}>
+    <li className={STATUS['option']}>
       <Label htmlFor={id}>{children}</Label>
       <Input
         type="checkbox"


### PR DESCRIPTION
## 개요

- 드롭다운의 모양을 가지긴 했지만 마크업상 `<select>` 가 아닌데, `select` 를 extend하고 있어서 이를 수정합니다.

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).