### PR TITLE
Feat: Schedule 도메인 수정, 삭제 API 구현

### DIFF
--- a/backend/src/main/java/com/pppppp/amadda/schedule/controller/ScheduleController.java
+++ b/backend/src/main/java/com/pppppp/amadda/schedule/controller/ScheduleController.java
@@ -3,8 +3,10 @@ package com.pppppp.amadda.schedule.controller;
 import com.pppppp.amadda.alarm.service.AlarmService;
 import com.pppppp.amadda.global.dto.ApiResponse;
 import com.pppppp.amadda.schedule.dto.request.CategoryCreateRequest;
+import com.pppppp.amadda.schedule.dto.request.CategoryPatchRequest;
 import com.pppppp.amadda.schedule.dto.request.CommentCreateRequest;
 import com.pppppp.amadda.schedule.dto.request.ScheduleCreateRequest;
+import com.pppppp.amadda.schedule.dto.request.SchedulePatchRequest;
 import com.pppppp.amadda.schedule.dto.response.CategoryReadResponse;
 import com.pppppp.amadda.schedule.dto.response.CommentReadResponse;
 import com.pppppp.amadda.schedule.dto.response.ScheduleCreateResponse;
@@ -18,9 +20,11 @@ import java.util.Map;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -84,6 +88,21 @@ public class ScheduleController {
             .orElseGet(() -> ApiResponse.ok(scheduleService.getParticipatingUserList(scheduleSeq)));
     }
 
+    @PutMapping("/{scheduleSeq}")
+    public ApiResponse<String> updateSchedule(@PathVariable Long scheduleSeq,
+        @Valid @RequestBody SchedulePatchRequest request) {
+        log.info("PUT /api/schedule/{}", scheduleSeq);
+        scheduleService.updateSchedule(mockUserSeq, scheduleSeq, request);
+        return ApiResponse.ok("수정되었습니다.");
+    }
+
+    @DeleteMapping("/{scheduleSeq}")
+    public ApiResponse<String> deleteSchedule(@PathVariable Long scheduleSeq) {
+        log.info("DELETE /api/schedule/{}", scheduleSeq);
+        scheduleService.deleteSchedule(mockUserSeq, scheduleSeq);
+        return ApiResponse.ok("삭제되었습니다.");
+    }
+
     // ==================== 댓글 ====================
 
     @PostMapping("/{scheduleSeq}/comment")
@@ -92,6 +111,14 @@ public class ScheduleController {
         log.info("POST /api/schedule/{}/comment", scheduleSeq);
         return ApiResponse.ok(
             scheduleService.createCommentOnSchedule(scheduleSeq, mockUserSeq, request));
+    }
+
+    @DeleteMapping("/{scheduleSeq}/comment/{commentSeq}")
+    public ApiResponse<String> deleteComment(@PathVariable Long scheduleSeq,
+        @PathVariable Long commentSeq) {
+        log.info("DELETE /api/schedule/{}/comment/{}", scheduleSeq, commentSeq);
+        scheduleService.deleteComment(commentSeq, mockUserSeq);
+        return ApiResponse.ok("삭제되었습니다.");
     }
 
     // ==================== 카테고리 ====================
@@ -107,6 +134,21 @@ public class ScheduleController {
     public ApiResponse<List<CategoryReadResponse>> getCategoryList() {
         log.info("GET /api/schedule/user/category");
         return ApiResponse.ok(scheduleService.getCategoryList(mockUserSeq));
+    }
+
+    @PutMapping("/user/category/{categorySeq}")
+    public ApiResponse<String> updateCategory(@PathVariable Long categorySeq,
+        @Valid @RequestBody CategoryPatchRequest request) {
+        log.info("PUT /api/schedule/user/category/{}", categorySeq);
+        scheduleService.updateCategory(mockUserSeq, categorySeq, request);
+        return ApiResponse.ok("수정되었습니다.");
+    }
+
+    @DeleteMapping("/user/category/{categorySeq}")
+    public ApiResponse<String> deleteCategory(@PathVariable Long categorySeq) {
+        log.info("DELETE /api/schedule/user/category/{}", categorySeq);
+        scheduleService.deleteCategory(mockUserSeq, categorySeq);
+        return ApiResponse.ok("삭제되었습니다.");
     }
 
     // ==================== 개별 알림 설정 ====================

--- a/backend/src/main/java/com/pppppp/amadda/schedule/dto/request/CategoryPatchRequest.java
+++ b/backend/src/main/java/com/pppppp/amadda/schedule/dto/request/CategoryPatchRequest.java
@@ -1,12 +1,10 @@
 package com.pppppp.amadda.schedule.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 
 @Builder
 public record CategoryPatchRequest(
-    @NotNull(message = "유효하지 않은 카테고리입니다.") Long categorySeq,
     @NotBlank(message = "카테고리 이름을 입력해주세요!") String categoryName,
     @NotBlank(message = "카테고리 색을 설정해주세요!") String categoryColor
 ) {

--- a/backend/src/main/java/com/pppppp/amadda/schedule/dto/request/SchedulePatchRequest.java
+++ b/backend/src/main/java/com/pppppp/amadda/schedule/dto/request/SchedulePatchRequest.java
@@ -10,7 +10,6 @@ import lombok.Builder;
 @Builder
 public record SchedulePatchRequest(
     // ================= Schedule ===================
-    @NotNull(message = "유효하지 않은 일정입니다.") Long scheduleSeq,
     String scheduleContent,
     @NotNull(message = "시간 확정 여부가 결정되지 않았어요!") Boolean isTimeSelected,
     @NotNull(message = "날짜 확정 여부가 결정되지 않았어요!") Boolean isDateSelected,

--- a/backend/src/main/java/com/pppppp/amadda/schedule/service/ScheduleService.java
+++ b/backend/src/main/java/com/pppppp/amadda/schedule/service/ScheduleService.java
@@ -109,9 +109,10 @@ public class ScheduleService {
     }
 
     @Transactional
-    public ScheduleDetailReadResponse updateSchedule(Long userSeq, SchedulePatchRequest request) {
+    public ScheduleDetailReadResponse updateSchedule(Long userSeq, Long scheduleSeq,
+        SchedulePatchRequest request) {
         findUserInfo(userSeq);
-        Schedule schedule = findScheduleInfo(request.scheduleSeq());
+        Schedule schedule = findScheduleInfo(scheduleSeq);
 
         // 사용자가 권한이 없으면 안됨
         checkUserAuthorizedToSchedule(userSeq, schedule);
@@ -120,7 +121,7 @@ public class ScheduleService {
         schedule.updateScheduleInfo(request);
 
         // 2. 참가자 참석 정보 가져오기
-        Participation participation = findParticipationInfoBySchedule(request.scheduleSeq(),
+        Participation participation = findParticipationInfoBySchedule(scheduleSeq,
             userSeq);
 
         // 3. 개인 참석 정보 수정
@@ -129,7 +130,7 @@ public class ScheduleService {
         // 4. 추가되는 사용자가 있으면 새롭게 참가자 추가, 없으면 참가자 목록 수정
         updateParticipantList(userSeq, request, schedule);
 
-        return getScheduleDetail(request.scheduleSeq(), userSeq);
+        return getScheduleDetail(scheduleSeq, userSeq);
     }
 
     public void addScheduleToCategory(Long userSeq, Long scheduleSeq,
@@ -233,10 +234,11 @@ public class ScheduleService {
         return findCategoryListByUser(userSeq);
     }
 
-    public CategoryReadResponse updateCategory(Long userSeq, CategoryPatchRequest request) {
+    public CategoryReadResponse updateCategory(Long userSeq, Long categorySeq,
+        CategoryPatchRequest request) {
 
         // 카테고리 유효 체크
-        Category category = findCategoryInfo(request.categorySeq());
+        Category category = findCategoryInfo(categorySeq);
 
         // 요청한 사용자와 카테고리 주인이 다르면 안됨
         checkUserAuthorizedToCategory(userSeq, category);

--- a/backend/src/test/java/com/pppppp/amadda/schedule/controller/ScheduleControllerTest.java
+++ b/backend/src/test/java/com/pppppp/amadda/schedule/controller/ScheduleControllerTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -12,8 +13,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.pppppp.amadda.alarm.service.AlarmService;
 import com.pppppp.amadda.schedule.dto.request.CategoryCreateRequest;
+import com.pppppp.amadda.schedule.dto.request.CategoryPatchRequest;
 import com.pppppp.amadda.schedule.dto.request.CommentCreateRequest;
 import com.pppppp.amadda.schedule.dto.request.ScheduleCreateRequest;
+import com.pppppp.amadda.schedule.dto.request.SchedulePatchRequest;
 import com.pppppp.amadda.schedule.dto.response.ScheduleCreateResponse;
 import com.pppppp.amadda.schedule.entity.AlarmTime;
 import com.pppppp.amadda.schedule.service.ScheduleService;
@@ -420,6 +423,166 @@ class ScheduleControllerTest {
             .andExpect(jsonPath("$.message").value("알림 시간 설정이 필요해요!"));
     }
 
+    @DisplayName("일정 수정 시 일정 제목은 필수로 입력되어야 한다.")
+    @Test
+    void noScheduleNameToUpdate() throws Exception {
+
+        User user = User.create(1111L, "박동건", "icebearrrr", "imgUrl1");
+
+        SchedulePatchRequest request = SchedulePatchRequest.builder()
+            // schedule
+            .scheduleContent("수원 시민 회관")
+            .isDateSelected(true)
+            .isTimeSelected(true)
+            .isAllDay(false)
+            .scheduleStartAt("2023-11-18 18:30:00")
+            .scheduleEndAt("2023-11-18 20:30:00")
+            .participants(List.of(UserReadResponse.of(user)))
+            // participation
+            .scheduleMemo("수원역에서 걸어서 10분")
+            .alarmTime(AlarmTime.ONE_DAY_BEFORE)
+            .build();
+
+        mockMvc.perform(
+                put("/api/schedule/{scheduleSeq}", 1L)
+                    .content(objectMapper.writeValueAsString(request))
+                    .contentType(MediaType.APPLICATION_JSON)
+            ).andDo(
+                print()
+            )
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("400"))
+            .andExpect(jsonPath("$.message").value("일정 이름을 입력해주세요!"));
+    }
+
+    @DisplayName("일정 수정 시 날짜 확정 여부를 입력해야 한다.")
+    @Test
+    void noScheduleDateSelectedInfoToUpdate() throws Exception {
+        // given
+        User user = User.create(1111L, "박동건", "icebearrrr", "imgUrl1");
+
+        SchedulePatchRequest request = SchedulePatchRequest.builder()
+            // schedule
+            .scheduleContent("수원 시민 회관")
+            .isTimeSelected(true)
+            .isAllDay(false)
+            .scheduleStartAt("2023-11-18 18:30:00")
+            .scheduleEndAt("2023-11-18 20:30:00")
+            .participants(List.of(UserReadResponse.of(user)))
+            // participation
+            .scheduleName("합창단 공연")
+            .scheduleMemo("수원역에서 걸어서 10분")
+            .alarmTime(AlarmTime.ONE_DAY_BEFORE)
+            .build();
+
+        // when  // then
+        mockMvc.perform(
+                put("/api/schedule/{scheduleSeq}", 1L)
+                    .content(objectMapper.writeValueAsString(request))
+                    .contentType(MediaType.APPLICATION_JSON)
+            ).andDo(
+                print()
+            )
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.message").value("날짜 확정 여부가 결정되지 않았어요!"));
+    }
+
+    @DisplayName("일정 수정 시 시간 확정 여부를 입력해야 한다.")
+    @Test
+    void noScheduleTimeSelectedInfoToUpdate() throws Exception {
+        // given
+        User user = User.create(1111L, "박동건", "icebearrrr", "imgUrl1");
+
+        SchedulePatchRequest request = SchedulePatchRequest.builder()
+            .scheduleContent("수원 시민 회관")
+            .isDateSelected(true)
+            .isAllDay(false)
+            .scheduleStartAt("2023-11-18 18:30:00")
+            .scheduleEndAt("2023-11-18 20:30:00")
+            .participants(List.of(UserReadResponse.of(user)))
+            // participation
+            .scheduleName("합창단 공연")
+            .scheduleMemo("수원역에서 걸어서 10분")
+            .alarmTime(AlarmTime.ONE_DAY_BEFORE)
+            .build();
+
+        // when  // then
+        mockMvc.perform(
+                put("/api/schedule/{scheduleSeq}", 1L)
+                    .content(objectMapper.writeValueAsString(request))
+                    .contentType(MediaType.APPLICATION_JSON)
+            ).andDo(
+                print()
+            )
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.message").value("시간 확정 여부가 결정되지 않았어요!"));
+    }
+
+    @DisplayName("일정 수정 시 일정의 하루종일 여부를 전달해야 한다.")
+    @Test
+    void noScheduleIsAllDayInfoToUpdate() throws Exception {
+        // given
+        User user = User.create(1111L, "박동건", "icebearrrr", "imgUrl1");
+
+        SchedulePatchRequest request = SchedulePatchRequest.builder()
+            // schedule
+            .scheduleContent("수원 시민 회관")
+            .isDateSelected(true)
+            .isTimeSelected(true)
+            .scheduleStartAt("2023-11-18 18:30:00")
+            .scheduleEndAt("2023-11-18 20:30:00")
+            .participants(List.of(UserReadResponse.of(user)))
+            // participation
+            .scheduleName("합창단 공연")
+            .scheduleMemo("수원역에서 걸어서 10분")
+            .alarmTime(AlarmTime.ONE_DAY_BEFORE)
+            .build();
+
+        // when  // then
+        mockMvc.perform(
+                put("/api/schedule/{scheduleSeq}", 1L)
+                    .content(objectMapper.writeValueAsString(request))
+                    .contentType(MediaType.APPLICATION_JSON)
+            ).andDo(
+                print()
+            )
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.message").value("하루종일 지속되는 일정인지 알려주세요!"));
+    }
+
+    @DisplayName("일정 수정 시 알림시간 설정은 필수다.")
+    @Test
+    void noScheduleAlarmTimeInfoToUpdate() throws Exception {
+        // given
+        User user = User.create(1111L, "박동건", "icebearrrr", "imgUrl1");
+
+        ScheduleCreateRequest request = ScheduleCreateRequest.builder()
+            // schedule
+            .scheduleContent("수원 시민 회관")
+            .isDateSelected(true)
+            .isTimeSelected(true)
+            .isAllDay(false)
+            .isAuthorizedAll(true)
+            .scheduleStartAt("2023-11-18 18:30:00")
+            .scheduleEndAt("2023-11-18 20:30:00")
+            .participants(List.of(UserReadResponse.of(user)))
+            // participation
+            .scheduleName("합창단 공연")
+            .scheduleMemo("수원역에서 걸어서 10분")
+            .build();
+
+        // when  // then
+        mockMvc.perform(
+                post("/api/schedule")
+                    .content(objectMapper.writeValueAsString(request))
+                    .contentType(MediaType.APPLICATION_JSON)
+            ).andDo(
+                print()
+            )
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.message").value("알림 시간 설정이 필요해요!"));
+    }
+
     @DisplayName("내용이 없는 빈 댓글은 달 수 없다.")
     @Test
     void noCommentContent() throws Exception {
@@ -473,6 +636,42 @@ class ScheduleControllerTest {
             )
             .andExpect(status().isBadRequest())
             .andExpect(jsonPath("$.message").value("카테고리 색을 선택해주세요!"));
+    }
+
+    @DisplayName("카테고리 수정시 이름이 필요하다.")
+    @Test
+    void noCategoryNameToUpdate() throws Exception {
+        CategoryPatchRequest request = CategoryPatchRequest.builder()
+            .categoryColor("GREEN")
+            .build();
+
+        mockMvc.perform(
+                put("/api/schedule/user/category/{categorySeq}", 1L)
+                    .content(objectMapper.writeValueAsString(request))
+                    .contentType(MediaType.APPLICATION_JSON)
+            ).andDo(
+                print()
+            )
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.message").value("카테고리 이름을 입력해주세요!"));
+    }
+
+    @DisplayName("카테고리 수정시 카테고리 색을 지정해야 한다.")
+    @Test
+    void noCategoryColorToUpdate() throws Exception {
+        CategoryPatchRequest request = CategoryPatchRequest.builder()
+            .categoryName("합창단")
+            .build();
+
+        mockMvc.perform(
+                put("/api/schedule/user/category/{categorySeq}", 1L)
+                    .content(objectMapper.writeValueAsString(request))
+                    .contentType(MediaType.APPLICATION_JSON)
+            ).andDo(
+                print()
+            )
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.message").value("카테고리 색을 설정해주세요!"));
     }
 
     @DisplayName("일정의 댓글 알림을 설정한다.")

--- a/backend/src/test/java/com/pppppp/amadda/schedule/service/ScheduleServiceTest.java
+++ b/backend/src/test/java/com/pppppp/amadda/schedule/service/ScheduleServiceTest.java
@@ -598,7 +598,6 @@ class ScheduleServiceTest extends IntegrationTestSupport {
         Long scheduleSeq = scheduleRepository.findAll().get(0).getScheduleSeq();
 
         SchedulePatchRequest schedulePatchRequest = SchedulePatchRequest.builder()
-            .scheduleSeq(scheduleSeq)
             .scheduleName("안녕 나는 바뀐 일정 이름이야")
             .scheduleContent("여기는 동기화 되는 메모야")
             .scheduleMemo("이거는 안되는 메모고")
@@ -612,7 +611,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
 
         // when
         ScheduleDetailReadResponse response1 = scheduleService.updateSchedule(
-            u1.getUserSeq(), schedulePatchRequest);
+            u1.getUserSeq(), scheduleSeq, schedulePatchRequest);
         ScheduleDetailReadResponse response2 = scheduleService.getScheduleDetail(scheduleSeq,
             u2.getUserSeq());
 
@@ -655,7 +654,6 @@ class ScheduleServiceTest extends IntegrationTestSupport {
         Long scheduleSeq = scheduleRepository.findAll().get(0).getScheduleSeq();
 
         SchedulePatchRequest schedulePatchRequest = SchedulePatchRequest.builder()
-            .scheduleSeq(scheduleSeq)
             .scheduleName("안녕 나는 바뀐 일정 이름이야")
             .scheduleContent("여기는 동기화 되는 메모야")
             .scheduleMemo("이거는 안되는 메모고")
@@ -669,7 +667,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
 
         // when
         ScheduleDetailReadResponse response1 = scheduleService.updateSchedule(
-            u2.getUserSeq(), schedulePatchRequest);
+            u2.getUserSeq(), scheduleSeq, schedulePatchRequest);
         ScheduleDetailReadResponse response2 = scheduleService.getScheduleDetail(scheduleSeq,
             u3.getUserSeq());
 
@@ -713,7 +711,6 @@ class ScheduleServiceTest extends IntegrationTestSupport {
         Schedule s = scheduleRepository.findAll().get(0);
 
         SchedulePatchRequest request = SchedulePatchRequest.builder()
-            .scheduleSeq(s.getScheduleSeq())
             .scheduleName("안녕 나는 바뀐 일정 이름이야")
             .scheduleContent("여기는 동기화 되는 메모야")
             .scheduleMemo("이거는 안되는 메모고")
@@ -726,7 +723,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .build();
 
         // when
-        scheduleService.updateSchedule(u1.getUserSeq(), request);
+        scheduleService.updateSchedule(u1.getUserSeq(), s.getScheduleSeq(), request);
         List<Participation> result1 = participationRepository.findBySchedule_ScheduleSeqAndIsDeletedFalse(
             s.getScheduleSeq());
         Optional<Participation> result2 = participationRepository.findBySchedule_ScheduleSeqAndUser_UserSeqAndIsDeletedFalse(
@@ -1044,11 +1041,11 @@ class ScheduleServiceTest extends IntegrationTestSupport {
 
         // when
         CategoryPatchRequest request = CategoryPatchRequest.builder()
-            .categorySeq(category.getCategorySeq())
             .categoryName("자율기절")
             .categoryColor("GREEN")
             .build();
-        CategoryReadResponse response = scheduleService.updateCategory(u1.getUserSeq(), request);
+        CategoryReadResponse response = scheduleService.updateCategory(u1.getUserSeq(),
+            category.getCategorySeq(), request);
 
         // then
         assertThat(response)
@@ -1174,13 +1171,13 @@ class ScheduleServiceTest extends IntegrationTestSupport {
         Schedule schedule = scheduleRepository.findAll().get(0);
 
         SchedulePatchRequest patchRequest = SchedulePatchRequest.builder()
-            .scheduleSeq(schedule.getScheduleSeq() + 1)
             .scheduleName("안녕 나는 바뀐 일정 이름이야")
             .build();
 
         // when // then
         assertThatThrownBy(
-            () -> scheduleService.updateSchedule(user.getUserSeq(), patchRequest))
+            () -> scheduleService.updateSchedule(user.getUserSeq(), schedule.getScheduleSeq() + 1,
+                patchRequest))
             .isInstanceOf(RestApiException.class)
             .hasMessage("SCHEDULE_NOT_FOUND");
     }
@@ -1206,12 +1203,13 @@ class ScheduleServiceTest extends IntegrationTestSupport {
         Schedule schedule = scheduleRepository.findAll().get(0);
 
         SchedulePatchRequest patchRequest = SchedulePatchRequest.builder()
-            .scheduleSeq(schedule.getScheduleSeq())
             .scheduleName("안녕 나는 바뀐 일정 이름이야")
             .build();
 
         // when // then
-        assertThatThrownBy(() -> scheduleService.updateSchedule(u2.getUserSeq(), patchRequest))
+        assertThatThrownBy(
+            () -> scheduleService.updateSchedule(u2.getUserSeq(), schedule.getScheduleSeq(),
+                patchRequest))
             .isInstanceOf(RestApiException.class)
             .hasMessage("SCHEDULE_FORBIDDEN");
     }
@@ -1387,13 +1385,14 @@ class ScheduleServiceTest extends IntegrationTestSupport {
         Category category = categoryRepository.findAll().get(0);
 
         CategoryPatchRequest patchRequest = CategoryPatchRequest.builder()
-            .categorySeq(category.getCategorySeq() + 1)
             .categoryName("자율기절")
             .categoryColor("GREEN")
             .build();
 
         // when // then
-        assertThatThrownBy(() -> scheduleService.updateCategory(user.getUserSeq(), patchRequest))
+        assertThatThrownBy(
+            () -> scheduleService.updateCategory(user.getUserSeq(), category.getCategorySeq() + 1,
+                patchRequest))
             .isInstanceOf(RestApiException.class)
             .hasMessage("CATEGORY_NOT_FOUND");
     }
@@ -1411,13 +1410,14 @@ class ScheduleServiceTest extends IntegrationTestSupport {
         Category category = categoryRepository.findAll().get(0);
 
         CategoryPatchRequest patchRequest = CategoryPatchRequest.builder()
-            .categorySeq(category.getCategorySeq())
             .categoryName("자율기절")
             .categoryColor("GREEN")
             .build();
 
         // when // then
-        assertThatThrownBy(() -> scheduleService.updateCategory(u2.getUserSeq(), patchRequest))
+        assertThatThrownBy(
+            () -> scheduleService.updateCategory(u2.getUserSeq(), category.getCategorySeq(),
+                patchRequest))
             .isInstanceOf(RestApiException.class)
             .hasMessage("CATEGORY_FORBIDDEN");
     }


### PR DESCRIPTION
## 개요
- `ScheduleController`에서 관리하는 데이터들에 대한 수정, 삭제 API를 생성하였습니다.
- 수정시 seq 값을 `Request` DTO가 아니라 uri의 @PathVariable에서 받아오도록 수정하였습니다.

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).