### PR TITLE
Feat: 프론트엔드 axios 유틸 메서드 분리

### DIFF
--- a/frontend/_apps/notice/package.json
+++ b/frontend/_apps/notice/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@reduxjs/toolkit": "^1.9.7",
     "@vanilla-extract/css": "1.13.0",
+    "axios": "^1.6.0",
     "external-temporal": "workspace:*",
     "next": "13.4.12",
     "react": "18.2.0",

--- a/frontend/_apps/notice/utils/http.ts
+++ b/frontend/_apps/notice/utils/http.ts
@@ -1,5 +1,5 @@
-import Axios, { AxiosResponse } from 'axios';
-export const ROOT = process.env.SPRINT_ROOT as string;
+import Axios from 'axios';
+export const ROOT = process.env.SPRING_API_ROOT as string;
 
 const axios = Axios.create({
   baseURL: ROOT,

--- a/frontend/_apps/schedule/package.json
+++ b/frontend/_apps/schedule/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@reduxjs/toolkit": "^1.9.7",
     "@vanilla-extract/css": "1.13.0",
+    "axios": "^1.6.0",
     "external-temporal": "workspace:*",
     "next": "13.4.12",
     "react": "18.2.0",

--- a/frontend/_apps/schedule/utils/http.ts
+++ b/frontend/_apps/schedule/utils/http.ts
@@ -1,0 +1,17 @@
+import Axios from 'axios';
+export const ROOT = process.env.SPRING_API_ROOT as string;
+
+const axios = Axios.create({
+  baseURL: ROOT,
+});
+
+export const http = {
+  get: <Response = unknown>(url: string) =>
+    axios.get<Response>(url).then(res => res),
+  post: <Request = unknown, Response = unknown>(url: string, body?: Request) =>
+    axios.post<Response>(url, body).then(res => res),
+  patch: <Request = unknown, Response = unknown>(url: string, body?: Request) =>
+    axios.patch<Response>(url, body).then(res => res),
+  delete: <Response = unknown>(url: string) =>
+    axios.delete<Response>(url).then(res => res),
+};

--- a/frontend/_apps/shell/utils/http.ts
+++ b/frontend/_apps/shell/utils/http.ts
@@ -1,0 +1,17 @@
+import Axios from 'axios';
+export const ROOT = process.env.SPRING_API_ROOT as string;
+
+const axios = Axios.create({
+  baseURL: ROOT,
+});
+
+export const http = {
+  get: <Response = unknown>(url: string) =>
+    axios.get<Response>(url).then(res => res),
+  post: <Request = unknown, Response = unknown>(url: string, body?: Request) =>
+    axios.post<Response>(url, body).then(res => res),
+  patch: <Request = unknown, Response = unknown>(url: string, body?: Request) =>
+    axios.patch<Response>(url, body).then(res => res),
+  delete: <Response = unknown>(url: string) =>
+    axios.delete<Response>(url).then(res => res),
+};

--- a/frontend/_apps/user/package.json
+++ b/frontend/_apps/user/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@reduxjs/toolkit": "^1.9.7",
     "@vanilla-extract/css": "1.13.0",
+    "axios": "^1.6.0",
     "external-temporal": "workspace:*",
     "next": "13.4.12",
     "react": "18.2.0",

--- a/frontend/_apps/user/utils/http.ts
+++ b/frontend/_apps/user/utils/http.ts
@@ -1,0 +1,17 @@
+import Axios from 'axios';
+export const ROOT = process.env.SPRING_API_ROOT as string;
+
+const axios = Axios.create({
+  baseURL: ROOT,
+});
+
+export const http = {
+  get: <Response = unknown>(url: string) =>
+    axios.get<Response>(url).then(res => res),
+  post: <Request = unknown, Response = unknown>(url: string, body?: Request) =>
+    axios.post<Response>(url, body).then(res => res),
+  patch: <Request = unknown, Response = unknown>(url: string, body?: Request) =>
+    axios.patch<Response>(url, body).then(res => res),
+  delete: <Response = unknown>(url: string) =>
+    axios.delete<Response>(url).then(res => res),
+};

--- a/frontend/_packages/@external-temporal/package.json
+++ b/frontend/_packages/@external-temporal/package.json
@@ -15,7 +15,6 @@
     "@types/react": "18.2.28",
     "@types/react-dom": "18.2.14",
     "@vanilla-extract/css": "1.13.0",
-    "axios": "^1.6.0",
     "eslint-config-custom": "workspace:*",
     "react": "18.2.0",
     "tsconfig": "workspace:*",

--- a/frontend/_packages/@external-temporal/util/http.ts
+++ b/frontend/_packages/@external-temporal/util/http.ts
@@ -7,11 +7,11 @@ const axios = Axios.create({
 
 export const http = {
   get: <Response = unknown>(url: string) =>
-    axios.get<Response>(url).then(res => res.data),
+    axios.get<Response>(url).then(res => res),
   post: <Request = unknown, Response = unknown>(url: string, body?: Request) =>
-    axios.post<Response>(url, body).then(res => res.data),
+    axios.post<Response>(url, body).then(res => res),
   patch: <Request = unknown, Response = unknown>(url: string, body?: Request) =>
-    axios.patch<Response>(url, body).then(res => res.data),
+    axios.patch<Response>(url, body).then(res => res),
   delete: <Response = unknown>(url: string) =>
-    axios.delete<Response>(url).then(res => res.data),
+    axios.delete<Response>(url).then(res => res),
 };

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -192,6 +192,9 @@ importers:
       '@vanilla-extract/css':
         specifier: 1.13.0
         version: 1.13.0
+      axios:
+        specifier: ^1.6.0
+        version: 1.6.0
       external-temporal:
         specifier: workspace:*
         version: link:../../_packages/@external-temporal
@@ -274,6 +277,9 @@ importers:
       '@vanilla-extract/css':
         specifier: 1.13.0
         version: 1.13.0
+      axios:
+        specifier: ^1.6.0
+        version: 1.6.0
       external-temporal:
         specifier: workspace:*
         version: link:../../_packages/@external-temporal
@@ -447,6 +453,9 @@ importers:
       '@vanilla-extract/css':
         specifier: 1.13.0
         version: 1.13.0
+      axios:
+        specifier: ^1.6.0
+        version: 1.6.0
       external-temporal:
         specifier: workspace:*
         version: link:../../_packages/@external-temporal
@@ -541,9 +550,6 @@ importers:
       '@vanilla-extract/css':
         specifier: 1.13.0
         version: 1.13.0
-      axios:
-        specifier: ^1.6.0
-        version: 1.6.0
       eslint-config-custom:
         specifier: workspace:*
         version: link:../eslint-config-custom
@@ -6614,6 +6620,7 @@ packages:
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
       - debug
+    dev: false
 
   /axobject-query@3.1.1:
     resolution: {integrity: sha512-goKlv8DZrK9hUh975fnHzhNIO4jUnFCfv/dszV5VwUGDFjI6vQ2VwoyjYjYNEbBE8AH87TduWP5uyDR1D+Iteg==}


### PR DESCRIPTION
## 개요

- axios 유틸 메서드를 각 next app에 위치시켰습니다
- env 문제도 있고, ui 라이브러리에 axios 유틸 함수가 있는 것이 부적절해 보였습니다.
- 또, axios 의존성이 모든 app에 필요하기도 했고요. 이번 기회에 모두 설치해서 pnpm-lock도 업데이트해 놓았습니다.

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).