### PR TITLE
Feat: Schedule Mobile Daily Plate 추가

### DIFF
--- a/frontend/_apps/docs/.storybook/main.ts
+++ b/frontend/_apps/docs/.storybook/main.ts
@@ -89,7 +89,9 @@ const config: StorybookConfig = {
       //@ts-ignore
       ...config.resolve.alias,
       '#': path.resolve(__dirname, '../../../_packages/@external-temporal/'),
+      '@SCH': path.resolve(__dirname, '../../../_apps/schedule/'),
     };
+
     return config;
   },
 };

--- a/frontend/_apps/docs/stories/schedule/MobileDailyPlate.stories.ts
+++ b/frontend/_apps/docs/stories/schedule/MobileDailyPlate.stories.ts
@@ -6,7 +6,8 @@ const meta = {
   component: MobileDailyPlate,
   parameters: {
     layout: 'centered',
-    componentSubtitle: '하루 일정...뷰.....',
+    componentSubtitle:
+      '월간 뷰에서 날짜를 선택하면 보여질 하루 일정 정보입니다.',
   },
   tags: ['autodocs'],
   argTypes: {},
@@ -21,6 +22,7 @@ export const Primary: Story = {
       color: 'hotpink',
       scheduleName: '업무 미팅',
       person: 7,
+      allday: true,
       participants: [
         'https://amadda-bucket.s3.ap-northeast-2.amazonaws.com/1111_2023-11-10-15-04-51.jpg',
         'https://amadda-bucket.s3.ap-northeast-2.amazonaws.com/1111_2023-11-10-15-04-51.jpg',

--- a/frontend/_apps/docs/stories/schedule/MobileDailyPlate.stories.ts
+++ b/frontend/_apps/docs/stories/schedule/MobileDailyPlate.stories.ts
@@ -1,0 +1,62 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { MobileDailyPlate } from '../../../schedule/components/MobileDailyPlate/MobileDailyPlate';
+
+const meta = {
+  title: 'Schedule/MobileDailyPlate',
+  component: MobileDailyPlate,
+  parameters: {
+    layout: 'centered',
+    componentSubtitle: '하루 일정...뷰.....',
+  },
+  tags: ['autodocs'],
+  argTypes: {},
+} satisfies Meta<typeof MobileDailyPlate>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {
+  args: {
+    MobileDailyPlateProps: {
+      color: 'hotpink',
+      scheduleName: '업무 미팅',
+      person: 7,
+      participants: [
+        'https://amadda-bucket.s3.ap-northeast-2.amazonaws.com/1111_2023-11-10-15-04-51.jpg',
+        'https://amadda-bucket.s3.ap-northeast-2.amazonaws.com/1111_2023-11-10-15-04-51.jpg',
+        'https://amadda-bucket.s3.ap-northeast-2.amazonaws.com/1111_2023-11-10-15-04-51.jpg',
+      ],
+      startTime: '09:00',
+      endTime: '11:00',
+    },
+  },
+};
+
+export const Zero: Story = {
+  args: {
+    MobileDailyPlateProps: {
+      color: 'hotpink',
+      scheduleName: '업무 미팅',
+      person: 1,
+      startTime: '09:00',
+      endTime: '11:00',
+    },
+  },
+};
+
+export const Over: Story = {
+  args: {
+    MobileDailyPlateProps: {
+      color: 'hotpink',
+      scheduleName: '업무 미팅',
+      person: 3,
+      participants: [
+        'https://amadda-bucket.s3.ap-northeast-2.amazonaws.com/1111_2023-11-10-15-04-51.jpg',
+        'https://amadda-bucket.s3.ap-northeast-2.amazonaws.com/1111_2023-11-10-15-04-51.jpg',
+        'https://amadda-bucket.s3.ap-northeast-2.amazonaws.com/1111_2023-11-10-15-04-51.jpg',
+      ],
+      startTime: '09:00',
+      endTime: '11:00',
+    },
+  },
+};

--- a/frontend/_apps/notice/next.config.js
+++ b/frontend/_apps/notice/next.config.js
@@ -2,6 +2,7 @@ const NextFederationPlugin = require('@module-federation/nextjs-mf');
 const { createVanillaExtractPlugin } = require('@vanilla-extract/next-plugin');
 const withVanillaExtract = createVanillaExtractPlugin();
 module.exports = withVanillaExtract({
+  domains: [process.env.KAKAO_CDN_DOMAIN, process.env.S3_DOMAIN],
   transpilePackages: ['ui'],
   basePath: '/mf/notice',
   webpack(config, options) {

--- a/frontend/_apps/schedule/components/MobileDailyPlate/MobileDailyPlate.css.ts
+++ b/frontend/_apps/schedule/components/MobileDailyPlate/MobileDailyPlate.css.ts
@@ -1,0 +1,48 @@
+import colors from '#/constants/colors';
+import { styleVariants } from '@vanilla-extract/css';
+
+export const LAYOUT = styleVariants({
+  plate: {
+    width: '21rem',
+    height: '2rem',
+    display: 'flex',
+    justifyContent: 'space-between',
+    flexGrow: '1',
+  },
+  category: {
+    width: '4px',
+    height: '2rem',
+  },
+  profiles: {
+    width: '2rem',
+    height: '2rem',
+    borderRadius: '100%',
+    position: 'relative',
+  },
+  width: {
+    width: '4rem',
+  },
+  time: {
+    width: '4rem',
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'end',
+    justifyContent: 'end',
+  },
+});
+
+export const CATEGORY = styleVariants({
+  salmon: [LAYOUT.category, { backgroundColor: colors.category.salmon }],
+  yellow: [LAYOUT.category, { backgroundColor: colors.category.yellow }],
+  cyan: [LAYOUT.category, { backgroundColor: colors.category.cyan }],
+  orange: [LAYOUT.category, { backgroundColor: colors.category.orange }],
+  hotpink: [LAYOUT.category, { backgroundColor: colors.category.hotpink }],
+  green: [LAYOUT.category, { backgroundColor: colors.category.green }],
+  grey: [LAYOUT.category, { backgroundColor: colors.category.grey }],
+});
+
+export const PROFILE = styleVariants({
+  0: [LAYOUT.profiles, { left: '2rem' }],
+  1: [LAYOUT.profiles, { left: '1rem' }],
+  2: [LAYOUT.profiles],
+});

--- a/frontend/_apps/schedule/components/MobileDailyPlate/MobileDailyPlate.css.ts
+++ b/frontend/_apps/schedule/components/MobileDailyPlate/MobileDailyPlate.css.ts
@@ -10,7 +10,7 @@ export const LAYOUT = styleVariants({
     flexGrow: '1',
   },
   category: {
-    width: '4px',
+    width: '0.25rem',
     height: '2rem',
   },
   profiles: {

--- a/frontend/_apps/schedule/components/MobileDailyPlate/MobileDailyPlate.css.ts
+++ b/frontend/_apps/schedule/components/MobileDailyPlate/MobileDailyPlate.css.ts
@@ -3,7 +3,7 @@ import { styleVariants } from '@vanilla-extract/css';
 
 export const LAYOUT = styleVariants({
   plate: {
-    width: '21rem',
+    width: '100%',
     height: '2rem',
     display: 'flex',
     justifyContent: 'space-between',

--- a/frontend/_apps/schedule/components/MobileDailyPlate/MobileDailyPlate.tsx
+++ b/frontend/_apps/schedule/components/MobileDailyPlate/MobileDailyPlate.tsx
@@ -1,6 +1,7 @@
-import { Flex, Profile, Spacing, Span } from '#/index';
+import { Flex, Profile, Spacing, Span } from 'external-temporal';
 import React from 'react';
 import { CATEGORY, LAYOUT, PROFILE } from './MobileDailyPlate.css';
+import DAILYPLATE_TEXT from '@SCH/constants/DAILYPLATE_TEXT';
 
 export interface MobileDailyPlateProps {
   color: keyof typeof CATEGORY;
@@ -39,7 +40,9 @@ export function MobileDailyPlate({ MobileDailyPlateProps }: PropsObj) {
           </Flex>
           <Spacing size="0.25" dir="h" />
           {MobileDailyPlateProps.person > 3 && (
-            <Span>외 {MobileDailyPlateProps.person - 3}명</Span>
+            <Span>
+              {DAILYPLATE_TEXT.PARTICIPANTS(MobileDailyPlateProps.person - 3)}
+            </Span>
           )}
         </Flex>
       )}
@@ -47,12 +50,12 @@ export function MobileDailyPlate({ MobileDailyPlateProps }: PropsObj) {
         <Spacing size="2" dir="h" />
         {MobileDailyPlateProps.unscheduled && (
           <div className={LAYOUT.width}>
-            <Span color="lightgrey">―</Span>
+            <Span color="lightgrey">{DAILYPLATE_TEXT.UNSCHEDULED}</Span>
           </div>
         )}
         {MobileDailyPlateProps.allday && (
           <div className={LAYOUT.width}>
-            <Span>하루종일</Span>
+            <Span>{DAILYPLATE_TEXT.ALLDAY}</Span>
           </div>
         )}
         {!MobileDailyPlateProps.unscheduled &&

--- a/frontend/_apps/schedule/components/MobileDailyPlate/MobileDailyPlate.tsx
+++ b/frontend/_apps/schedule/components/MobileDailyPlate/MobileDailyPlate.tsx
@@ -1,0 +1,68 @@
+import { Flex, Profile, Spacing, Span } from '#/index';
+import React from 'react';
+import { CATEGORY, LAYOUT, PROFILE } from './MobileDailyPlate.css';
+
+export interface MobileDailyPlateProps {
+  color: keyof typeof CATEGORY;
+  scheduleName: string;
+  person: number;
+  participants?: string[];
+  unscheduled?: boolean;
+  allday?: boolean;
+  startTime?: string;
+  endTime?: string;
+}
+
+export interface PropsObj {
+  MobileDailyPlateProps: MobileDailyPlateProps;
+}
+export function MobileDailyPlate({ MobileDailyPlateProps }: PropsObj) {
+  return (
+    <div className={LAYOUT.plate}>
+      <Flex flexDirection="row" justifyContents="start">
+        <div className={CATEGORY[MobileDailyPlateProps.color]} />
+        <Spacing size="0.5" dir="h" />
+        <Span>{MobileDailyPlateProps.scheduleName}</Span>
+      </Flex>
+      {MobileDailyPlateProps.person > 1 && (
+        <Flex flexDirection="row" justifyContents="end" alignItems="center">
+          <Flex
+            flexDirection="row"
+            justifyContents="center"
+            alignItems="center"
+          >
+            {MobileDailyPlateProps.participants?.map((participant, idx) => (
+              <div className={PROFILE[idx]}>
+                <Profile src={participant} alt="part" size="small" />
+              </div>
+            ))}
+          </Flex>
+          <Spacing size="0.25" dir="h" />
+          {MobileDailyPlateProps.person > 3 && (
+            <Span>외 {MobileDailyPlateProps.person - 3}명</Span>
+          )}
+        </Flex>
+      )}
+      <Flex flexDirection="row" justifyContents="start">
+        <Spacing size="2" dir="h" />
+        {MobileDailyPlateProps.unscheduled && (
+          <div className={LAYOUT.width}>
+            <Span color="lightgrey">―</Span>
+          </div>
+        )}
+        {MobileDailyPlateProps.allday && (
+          <div className={LAYOUT.width}>
+            <Span>하루종일</Span>
+          </div>
+        )}
+        {!MobileDailyPlateProps.unscheduled &&
+          !MobileDailyPlateProps.allday && (
+            <div className={LAYOUT.time}>
+              <Span>{MobileDailyPlateProps.startTime}</Span>
+              <Span>{MobileDailyPlateProps.endTime}</Span>
+            </div>
+          )}
+      </Flex>
+    </div>
+  );
+}

--- a/frontend/_apps/schedule/constants/DAILYPLATE_TEXT.ts
+++ b/frontend/_apps/schedule/constants/DAILYPLATE_TEXT.ts
@@ -1,0 +1,5 @@
+export default {
+  ALLDAY: '하루종일',
+  UNSCHEDULED: '―',
+  PARTICIPANTS: (person: number) => `외 ${person}}명`,
+};

--- a/frontend/_apps/schedule/next.config.js
+++ b/frontend/_apps/schedule/next.config.js
@@ -2,6 +2,7 @@ const NextFederationPlugin = require('@module-federation/nextjs-mf');
 const { createVanillaExtractPlugin } = require('@vanilla-extract/next-plugin');
 const withVanillaExtract = createVanillaExtractPlugin();
 module.exports = withVanillaExtract({
+  domains: [process.env.KAKAO_CDN_DOMAIN, process.env.S3_DOMAIN],
   transpilePackages: ['ui'],
   basePath: '/mf/schedule',
   webpack(config, options) {

--- a/frontend/_apps/schedule/tsconfig.json
+++ b/frontend/_apps/schedule/tsconfig.json
@@ -4,8 +4,7 @@
     "plugins": [{ "name": "next" }],
     "baseUrl": "./",
     "paths": {
-      "@/*": ["./*"],
-      "#/*": ["../../_packages/@external-temporal/*"],
+      "@SCH/*": ["./*"],
       "#/components/*": ["../../_packages/@external-temporal/components/*"],
       "#/constants/*": ["../../_packages/@external-temporal/constants/*"]
     }

--- a/frontend/_apps/shell/next.config.js
+++ b/frontend/_apps/shell/next.config.js
@@ -3,7 +3,7 @@ const { createVanillaExtractPlugin } = require('@vanilla-extract/next-plugin');
 const withVanillaExtract = createVanillaExtractPlugin();
 module.exports = withVanillaExtract({
   images: {
-    domains: [process.env.KAKAO_CDN_DOMAIN],
+    domains: [process.env.KAKAO_CDN_DOMAIN, process.env.S3_DOMAIN],
   },
   transpilePackages: ['ui'],
   webpack(config, options) {

--- a/frontend/_apps/user/next.config.js
+++ b/frontend/_apps/user/next.config.js
@@ -2,6 +2,7 @@ const NextFederationPlugin = require('@module-federation/nextjs-mf');
 const { createVanillaExtractPlugin } = require('@vanilla-extract/next-plugin');
 const withVanillaExtract = createVanillaExtractPlugin();
 module.exports = withVanillaExtract({
+  domains: [process.env.KAKAO_CDN_DOMAIN, process.env.S3_DOMAIN],
   transpilePackages: ['ui'],
   basePath: '/mf/user',
   webpack(config, options) {

--- a/frontend/_packages/@external-temporal/components/layout/Flex.css.ts
+++ b/frontend/_packages/@external-temporal/components/layout/Flex.css.ts
@@ -7,6 +7,7 @@ export const DIRECTION_VARIANT = styleVariants({
 
 export const JUSTIFY_VARIANT = styleVariants({
   start: { justifyContent: 'start' },
+  end: { justifyContent: 'end' },
   center: { justifyContent: 'center' },
   spaceBetween: { justifyContent: 'space-between' },
   spaceAround: { justifyContent: 'space-around' },

--- a/frontend/_packages/@external-temporal/components/typography/Text/Span.tsx
+++ b/frontend/_packages/@external-temporal/components/typography/Text/Span.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import type { HTMLAttributes } from 'react';
+import type { HTMLAttributes, ReactNode } from 'react';
 import { COLOR } from './Texts.css';
 
 export interface SpanProps extends HTMLAttributes<HTMLSpanElement> {
   color?: keyof typeof COLOR;
-  children: string;
+  children: ReactNode;
 }
 export function Span({ color = 'black', children }: SpanProps) {
   return <span className={COLOR[color]}>{children}</span>;

--- a/frontend/_packages/@external-temporal/components/view/Profile/Profile.css.ts
+++ b/frontend/_packages/@external-temporal/components/view/Profile/Profile.css.ts
@@ -11,4 +11,9 @@ export const FRAME = styleVariants({
     width: '3rem',
     height: '3rem',
   },
+  small: {
+    position: 'relative',
+    width: '2rem',
+    height: '2rem',
+  },
 });


### PR DESCRIPTION
## 개요
1. Flex, Profile 컴포넌트의 일부 css를 변경했어요.
2. Span children 타입을 string에서 ReactNode로 변경했어요.
3. 각 모듈별 next.config.js에 next/Image 사용에 필요한 `domains` 속성을 추가했어요.
4. Schedule 모듈 안에 MobileDailyPlate 컴포넌트를 추가했어요.
- https://github.com/pp-pppp/amadda/pull/148/commits/e9c85dcc441daf6045d678a1fd4c56afe6390317 은 테스트 용으로 지정해놓았던 width를 실제 구현 시에 사용할 값으로 변경한 커밋입니다. 이에 storybook을 실행하면 예시 타입 별로 width가 다르게 보입니다. 실제 사용시에는 부모 컴포넌트의 width와 동일해집니다.

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).