### PR TITLE
Refactor: 일정 다중 조회 API 반환 타입 List -> Map으로 변경

### DIFF
--- a/backend/src/main/java/com/pppppp/amadda/schedule/controller/ScheduleController.java
+++ b/backend/src/main/java/com/pppppp/amadda/schedule/controller/ScheduleController.java
@@ -69,7 +69,7 @@ public class ScheduleController {
     }
 
     @GetMapping("")
-    public ApiResponse<List<ScheduleListReadResponse>> getScheduleList(
+    public ApiResponse<Map<String, List<ScheduleListReadResponse>>> getScheduleList(
         @RequestParam(value = "category", required = false) Optional<String> categorySeqList,
         @RequestParam(value = "searchKey", required = false) Optional<String> searchKey,
         @RequestParam(value = "unscheduled", required = false) Optional<String> unscheduled,
@@ -86,7 +86,7 @@ public class ScheduleController {
             year.orElse(""), "month",
             month.orElse(""), "day", day.orElse(""));
 
-        return ApiResponse.ok(scheduleService.getScheduleListBySearchCondition(mockUserSeq,
+        return ApiResponse.ok(scheduleService.getScheduleListByCondition(mockUserSeq,
             searchCondition));
     }
 

--- a/backend/src/main/java/com/pppppp/amadda/schedule/service/ScheduleService.java
+++ b/backend/src/main/java/com/pppppp/amadda/schedule/service/ScheduleService.java
@@ -445,28 +445,28 @@ public class ScheduleService {
     }
 
     private void checkUserAuthorizedToSchedule(Long userSeq, Schedule schedule) {
-        if (!(schedule.isAuthorizedAll() || schedule.getAuthorizedUser().getUserSeq()
-            .equals(userSeq))) {
+        // 일정이 전체에게 공개되어 있지도 않은데 사용자가 권한이 없으면 안됨
+        if (!(schedule.isAuthorizedAll()
+            || !isSameUser(userSeq, schedule.getAuthorizedUser().getUserSeq()))) {
             throw new RestApiException(ScheduleErrorCode.SCHEDULE_FORBIDDEN);
         }
     }
 
-    private void checkUserAuthorizedToParticipation(Long userSeq, Participation particiption) {
-        if (!(particiption.getUser().getUserSeq().equals(userSeq) || particiption.getSchedule()
-            .getAuthorizedUser().getUserSeq().equals(userSeq))) {
+    private void checkUserAuthorizedToParticipation(Long userSeq, Participation participation) {
+        if (!(isSameUser(userSeq, participation.getUser().getUserSeq())
+            || isSameUser(userSeq, participation.getSchedule().getAuthorizedUser().getUserSeq()))) {
             throw new RestApiException(ScheduleErrorCode.SCHEDULE_FORBIDDEN);
         }
     }
 
     private void checkUserAuthorizedToComment(Long userSeq, Comment comment) {
-        if (!comment.getUser().getUserSeq().equals(userSeq)) {
+        if (!isSameUser(userSeq, comment.getUser().getUserSeq())) {
             throw new RestApiException(CommentErrorCode.COMMENT_FORBIDDEN);
         }
     }
 
     private void checkUserAuthorizedToCategory(Long userSeq, Category category) {
-
-        if (!category.getUser().getUserSeq().equals(userSeq)) {
+        if (!isSameUser(userSeq, category.getUser().getUserSeq())) {
             throw new RestApiException(CategoryErrorCode.CATEGORY_FORBIDDEN);
         }
     }

--- a/backend/src/main/java/com/pppppp/amadda/schedule/service/ScheduleService.java
+++ b/backend/src/main/java/com/pppppp/amadda/schedule/service/ScheduleService.java
@@ -37,13 +37,13 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
+import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.TreeMap;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -127,7 +127,7 @@ public class ScheduleService {
             userSeq, searchCondition);
 
         // 반환할 map 생성
-        Map<String, List<ScheduleListReadResponse>> response = new TreeMap<>(Map.of());
+        Map<String, List<ScheduleListReadResponse>> response = new HashMap<>(Map.of());
 
         // 날짜 확정 / 미확정, 일자별로 정리하며 입력
         scheduleListByCondition.forEach(
@@ -137,7 +137,7 @@ public class ScheduleService {
                     if (response.containsKey("unscheduled")) {
                         response.get("unscheduled").add(schedule);
                     } else {
-                        response.put("unscheduled", new ArrayList<>());
+                        response.put("unscheduled", new LinkedList<>());
                         response.get("unscheduled").add(schedule);
                     }
                 }
@@ -155,7 +155,7 @@ public class ScheduleService {
                         if (response.containsKey(date)) {
                             response.get(date).add(schedule);
                         } else {
-                            response.put(date, new ArrayList<>());
+                            response.put(date, new LinkedList<>());
                             response.get(date).add(schedule);
                         }
                     }
@@ -189,7 +189,7 @@ public class ScheduleService {
                             if (response.containsKey(dateString)) {
                                 response.get(dateString).add(schedule);
                             } else {
-                                response.put(dateString, new ArrayList<>());
+                                response.put(dateString, new LinkedList<>());
                                 response.get(dateString).add(schedule);
                             }
                         }

--- a/backend/src/main/java/com/pppppp/amadda/schedule/service/ScheduleService.java
+++ b/backend/src/main/java/com/pppppp/amadda/schedule/service/ScheduleService.java
@@ -37,13 +37,13 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
-import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.TreeMap;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -127,7 +127,7 @@ public class ScheduleService {
             userSeq, searchCondition);
 
         // 반환할 map 생성
-        Map<String, List<ScheduleListReadResponse>> response = new HashMap<>(Map.of());
+        Map<String, List<ScheduleListReadResponse>> response = new TreeMap<>(Map.of());
 
         // 날짜 확정 / 미확정, 일자별로 정리하며 입력
         scheduleListByCondition.forEach(
@@ -137,7 +137,7 @@ public class ScheduleService {
                     if (response.containsKey("unscheduled")) {
                         response.get("unscheduled").add(schedule);
                     } else {
-                        response.put("unscheduled", new LinkedList<>());
+                        response.put("unscheduled", new ArrayList<>());
                         response.get("unscheduled").add(schedule);
                     }
                 }
@@ -155,7 +155,7 @@ public class ScheduleService {
                         if (response.containsKey(date)) {
                             response.get(date).add(schedule);
                         } else {
-                            response.put(date, new LinkedList<>());
+                            response.put(date, new ArrayList<>());
                             response.get(date).add(schedule);
                         }
                     }
@@ -189,7 +189,7 @@ public class ScheduleService {
                             if (response.containsKey(dateString)) {
                                 response.get(dateString).add(schedule);
                             } else {
-                                response.put(dateString, new LinkedList<>());
+                                response.put(dateString, new ArrayList<>());
                                 response.get(dateString).add(schedule);
                             }
                         }
@@ -197,8 +197,6 @@ public class ScheduleService {
                 }
             }
         );
-
-        System.out.println(response);
 
         return response;
     }

--- a/backend/src/test/java/com/pppppp/amadda/schedule/controller/ScheduleControllerTest.java
+++ b/backend/src/test/java/com/pppppp/amadda/schedule/controller/ScheduleControllerTest.java
@@ -134,7 +134,7 @@ class ScheduleControllerTest {
             )
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.code").value("200"))
-            .andExpect(jsonPath("$.data").isArray());
+            .andExpect(jsonPath("$.data").isMap());
     }
 
     @DisplayName("query string을 통해 입력받은 조건에 맞는 일정 목록을 조회한다.")
@@ -156,7 +156,7 @@ class ScheduleControllerTest {
                 print()
             ).andExpect(status().isOk())
             .andExpect(jsonPath("$.code").value("200"))
-            .andExpect(jsonPath("$.data").isArray());
+            .andExpect(jsonPath("$.data").isMap());
 
     }
 
@@ -175,7 +175,7 @@ class ScheduleControllerTest {
             )
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.code").value("200"))
-            .andExpect(jsonPath("$.data").isArray());
+            .andExpect(jsonPath("$.data").isMap());
     }
 
     @DisplayName("이름으로 일정을 검색한다.")
@@ -193,7 +193,7 @@ class ScheduleControllerTest {
             )
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.code").value("200"))
-            .andExpect(jsonPath("$.data").isArray());
+            .andExpect(jsonPath("$.data").isMap());
     }
 
     @DisplayName("사용자의 미확정 일정을 조회한다.")
@@ -211,7 +211,7 @@ class ScheduleControllerTest {
             )
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.code").value("200"))
-            .andExpect(jsonPath("$.data").isArray());
+            .andExpect(jsonPath("$.data").isMap());
     }
 
     @DisplayName("날짜 조건에 맞는 일정 목록을 가져온다.")
@@ -230,7 +230,7 @@ class ScheduleControllerTest {
                 print()
             ).andExpect(status().isOk())
             .andExpect(jsonPath("$.code").value("200"))
-            .andExpect(jsonPath("$.data").isArray());
+            .andExpect(jsonPath("$.data").isMap());
     }
 
     @DisplayName("일정 내 참가자 명단에서 사용자를 검색한다.")

--- a/backend/src/test/java/com/pppppp/amadda/schedule/service/ScheduleServiceTest.java
+++ b/backend/src/test/java/com/pppppp/amadda/schedule/service/ScheduleServiceTest.java
@@ -729,8 +729,6 @@ class ScheduleServiceTest extends IntegrationTestSupport {
                 tuple("2023-11-01 08:59:30", "2023-11-01 09:00:00")
             );
 
-        System.out.println(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>" + mapResult1.keySet());
-
         assertThat(mapResult1)
             .hasSize(30)
             // 2023년 11월 1일부터 2023년 11월 30일까지 다 포함

--- a/backend/src/test/java/com/pppppp/amadda/schedule/service/ScheduleServiceTest.java
+++ b/backend/src/test/java/com/pppppp/amadda/schedule/service/ScheduleServiceTest.java
@@ -189,7 +189,6 @@ class ScheduleServiceTest extends IntegrationTestSupport {
                 tuple("minyoung", "정민영", "url2"));
     }
 
-
     @DisplayName("일정이 확정된 새로운 일정을 생성하고, 사용자의 개인화 된 설정이 반영 되었는지 확인한다.")
     @Test
     void createFixedScheduleAndParticipation() {
@@ -329,7 +328,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .isDateSelected(true)
             .isAllDay(false)
             .scheduleStartAt("2023-11-01 08:59:30")
-            .scheduleEndAt("2023-11-01 09:00:00")
+            .scheduleEndAt("2023-11-02 09:00:00")
             .isAuthorizedAll(false)
             .alarmTime(AlarmTime.ON_TIME)
             .participants(List.of(UserReadResponse.of(u2)))
@@ -343,6 +342,10 @@ class ScheduleServiceTest extends IntegrationTestSupport {
         List<ScheduleListReadResponse> user1Schedules = scheduleService.getScheduleListBySearchCondition(
             u1.getUserSeq(), searchCondition);
         List<ScheduleListReadResponse> user2Schedules = scheduleService.getScheduleListBySearchCondition(
+            u2.getUserSeq(), searchCondition);
+        Map<String, List<ScheduleListReadResponse>> user1Result = scheduleService.getScheduleListByCondition(
+            u1.getUserSeq(), searchCondition);
+        Map<String, List<ScheduleListReadResponse>> user2Result = scheduleService.getScheduleListByCondition(
             u2.getUserSeq(), searchCondition);
 
         // then
@@ -361,8 +364,14 @@ class ScheduleServiceTest extends IntegrationTestSupport {
                 tuple("안녕 내가 일정 이름이야", false, false, false,
                     "", "", AlarmTime.NONE.getContent(), false),
                 tuple("나도 일정이야", true, true, false,
-                    "2023-11-01 08:59:30", "2023-11-01 09:00:00", AlarmTime.ON_TIME.getContent(),
+                    "2023-11-01 08:59:30", "2023-11-02 09:00:00", AlarmTime.ON_TIME.getContent(),
                     false));
+        assertThat(user1Result)
+            .hasSize(1)
+            .containsKeys("unscheduled");
+        assertThat(user2Result)
+            .hasSize(3)
+            .containsKeys("unscheduled", "2023-11-01", "2023-11-02");
     }
 
     @DisplayName("일정의 상세 정보를 불러온다.")
@@ -459,6 +468,10 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             u1.getUserSeq(), searchCondition1);
         List<ScheduleListReadResponse> result2 = scheduleService.getScheduleListBySearchCondition(
             u1.getUserSeq(), searchCondition2);
+        Map<String, List<ScheduleListReadResponse>> mapResult1 = scheduleService.getScheduleListByCondition(
+            u1.getUserSeq(), searchCondition1);
+        Map<String, List<ScheduleListReadResponse>> mapResult2 = scheduleService.getScheduleListByCondition(
+            u1.getUserSeq(), searchCondition2);
 
         // then
         assertThat(result1)
@@ -484,6 +497,12 @@ class ScheduleServiceTest extends IntegrationTestSupport {
                     List.of(UserReadResponse.of(u1)), UserReadResponse.of(u1), false, false, false,
                     "", "", AlarmTime.NONE.getContent(), false, CategoryReadResponse.of(c1))
             );
+        assertThat(mapResult1)
+            .hasSize(1)
+            .containsKeys("unscheduled");
+        assertThat(mapResult2)
+            .hasSize(1)
+            .containsKeys("unscheduled");
     }
 
     @DisplayName("일정 이름으로 일정을 검색한다.")
@@ -522,6 +541,8 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             "categories", "", "month", "", "day", "", "year", "");
         List<ScheduleListReadResponse> schedules = scheduleService.getScheduleListBySearchCondition(
             u1.getUserSeq(), searchCondition);
+        Map<String, List<ScheduleListReadResponse>> mapResult = scheduleService.getScheduleListByCondition(
+            u1.getUserSeq(), searchCondition);
 
         // then
         assertThat(schedules)
@@ -538,6 +559,8 @@ class ScheduleServiceTest extends IntegrationTestSupport {
                     "2023-11-01 08:59:30", "2023-11-01 09:00:00", AlarmTime.ON_TIME.getContent(),
                     false, null)
             );
+        assertThat(mapResult)
+            .containsKeys("unscheduled", "2023-11-01");
     }
 
     @DisplayName("사용자의 미확정인 일정 목록을 조회한다.")
@@ -576,6 +599,8 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             "unscheduled", "true", "month", "", "day", "", "year", "");
         List<ScheduleListReadResponse> result = scheduleService.getScheduleListBySearchCondition(
             u1.getUserSeq(), searchCondition);
+        Map<String, List<ScheduleListReadResponse>> mapResult = scheduleService.getScheduleListByCondition(
+            u1.getUserSeq(), searchCondition);
 
         // then
         assertThat(result)
@@ -588,6 +613,9 @@ class ScheduleServiceTest extends IntegrationTestSupport {
                     List.of(UserReadResponse.of(u1)), UserReadResponse.of(u1), false, false, false,
                     "", "", AlarmTime.NONE.getContent(), false, null)
             );
+        assertThat(mapResult)
+            .hasSize(1)
+            .containsKeys("unscheduled");
     }
 
     @DisplayName("사용자의 이번달 일정 목록을 조회한다.")
@@ -679,6 +707,10 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             u1.getUserSeq(), searchCondition);
         List<ScheduleListReadResponse> result2 = scheduleService.getScheduleListBySearchCondition(
             u2.getUserSeq(), searchCondition);
+        Map<String, List<ScheduleListReadResponse>> mapResult1 = scheduleService.getScheduleListByCondition(
+            u1.getUserSeq(), searchCondition);
+        Map<String, List<ScheduleListReadResponse>> mapResult2 = scheduleService.getScheduleListByCondition(
+            u2.getUserSeq(), searchCondition);
 
         // then
         assertThat(result1)
@@ -696,6 +728,23 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .containsExactlyInAnyOrder(
                 tuple("2023-11-01 08:59:30", "2023-11-01 09:00:00")
             );
+
+        System.out.println(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>" + mapResult1.keySet());
+
+        assertThat(mapResult1)
+            .hasSize(30)
+            // 2023년 11월 1일부터 2023년 11월 30일까지 다 포함
+            .containsKeys("2023-11-01", "2023-11-02", "2023-11-03", "2023-11-04",
+                "2023-11-05",
+                "2023-11-06", "2023-11-07", "2023-11-08", "2023-11-09", "2023-11-10", "2023-11-11",
+                "2023-11-12", "2023-11-13", "2023-11-14", "2023-11-15", "2023-11-16", "2023-11-17",
+                "2023-11-18", "2023-11-19", "2023-11-20", "2023-11-21", "2023-11-22", "2023-11-23",
+                "2023-11-24", "2023-11-25", "2023-11-26", "2023-11-27", "2023-11-28", "2023-11-29",
+                "2023-11-30");
+
+        assertThat(mapResult2)
+            .hasSize(1)
+            .containsKeys("2023-11-01");
     }
 
     @DisplayName("사용자의 오늘 일정 목록을 조회한다.")
@@ -775,6 +824,10 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             u1.getUserSeq(), searchCondition);
         List<ScheduleListReadResponse> result2 = scheduleService.getScheduleListBySearchCondition(
             u2.getUserSeq(), searchCondition);
+        Map<String, List<ScheduleListReadResponse>> mapResult1 = scheduleService.getScheduleListByCondition(
+            u1.getUserSeq(), searchCondition);
+        Map<String, List<ScheduleListReadResponse>> mapResult2 = scheduleService.getScheduleListByCondition(
+            u2.getUserSeq(), searchCondition);
 
         // then
         assertThat(result1)
@@ -790,6 +843,12 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .containsExactlyInAnyOrder(
                 tuple("2023-11-01 08:59:30", "2023-11-01 09:00:00")
             );
+        assertThat(mapResult1)
+            .hasSize(1)
+            .containsKeys("2023-11-01");
+        assertThat(mapResult2)
+            .hasSize(1)
+            .containsKeys("2023-11-01");
     }
 
     @DisplayName("일정 참가자 명단에서 이름으로 유저를 검색한다.")
@@ -1011,7 +1070,6 @@ class ScheduleServiceTest extends IntegrationTestSupport {
         assertThat(result2).isEmpty();
     }
 
-
     @DisplayName("카테고리에 새로운 일정을 추가한다.")
     @Transactional
     @Test
@@ -1065,7 +1123,6 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .extracting("scheduleSeq")
             .contains(schedule.scheduleSeq());
     }
-
 
     @DisplayName("카테고리에서 일정을 삭제한다.")
     @Transactional
@@ -1765,7 +1822,6 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .hasMessage("CATEGORY_ALREADY_EXISTS");
     }
 
-
     @DisplayName("날짜 조건으로 일정을 조회하려면 연 단위 입력이 있어야 한다.")
     @Transactional
     @Test
@@ -1927,7 +1983,6 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .isInstanceOf(RestApiException.class)
             .hasMessage("SCHEDULE_INVALID_REQUEST");
     }
-
 
     @DisplayName("유효하지 않은 카테고리에 접근해 수정에 실패한다.")
     @Test


### PR DESCRIPTION
## 개요
- 조건에 따르는 일정 목록을 가져오는 조회 API의 반환타입을 `List<ScheduleListReadResponse>`에서 `Map<String, List<ScheduleListReadResponse>>`으로 변경했습니다.
- 자료구조별 클래스는 `HashMap`, `LinkedList`를 사용했습니다. 

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).