### PR TITLE
Feat: 일정 수정 API 분리

### DIFF
--- a/backend/src/main/java/com/pppppp/amadda/schedule/controller/ScheduleController.java
+++ b/backend/src/main/java/com/pppppp/amadda/schedule/controller/ScheduleController.java
@@ -110,7 +110,7 @@ public class ScheduleController {
         Long userSeq = tokenProvider.getUserSeq(http);
         ScheduleUpdateResponse response = scheduleService.updateSchedule(userSeq, scheduleSeq,
             request);
-        return ApiResponse.of(HttpStatus.OK, "해당 일정을 수정했습니다", response);
+        return ApiResponse.of(HttpStatus.OK, "해당 일정을 수정했습니다.", response);
 
     }
 
@@ -122,7 +122,7 @@ public class ScheduleController {
         ParticipationUpdateResponse response = scheduleService.updateParticipation(userSeq,
             scheduleSeq,
             request);
-        return ApiResponse.of(HttpStatus.OK, "해당 일정의 참여자를 수정했습니다", response);
+        return ApiResponse.of(HttpStatus.OK, "해당 일정을 수정했습니다.", response);
 
     }
 

--- a/backend/src/main/java/com/pppppp/amadda/schedule/controller/ScheduleController.java
+++ b/backend/src/main/java/com/pppppp/amadda/schedule/controller/ScheduleController.java
@@ -5,11 +5,13 @@ import com.pppppp.amadda.global.util.TokenProvider;
 import com.pppppp.amadda.schedule.dto.request.CategoryCreateRequest;
 import com.pppppp.amadda.schedule.dto.request.CategoryUpdateRequest;
 import com.pppppp.amadda.schedule.dto.request.CommentCreateRequest;
+import com.pppppp.amadda.schedule.dto.request.ParticipationUpdateRequest;
 import com.pppppp.amadda.schedule.dto.request.ScheduleCreateRequest;
 import com.pppppp.amadda.schedule.dto.request.ScheduleUpdateRequest;
 import com.pppppp.amadda.schedule.dto.response.CategoryCreateResponse;
 import com.pppppp.amadda.schedule.dto.response.CategoryReadResponse;
 import com.pppppp.amadda.schedule.dto.response.CategoryUpdateResponse;
+import com.pppppp.amadda.schedule.dto.response.ParticipationUpdateResponse;
 import com.pppppp.amadda.schedule.dto.response.ScheduleCreateResponse;
 import com.pppppp.amadda.schedule.dto.response.ScheduleDetailReadResponse;
 import com.pppppp.amadda.schedule.dto.response.ScheduleListReadResponse;
@@ -42,7 +44,7 @@ public class ScheduleController {
 
     private final ScheduleService scheduleService;
     private final TokenProvider tokenProvider;
-    
+
     // ==================== 일정 ====================
 
     @PostMapping("")
@@ -109,6 +111,18 @@ public class ScheduleController {
         ScheduleUpdateResponse response = scheduleService.updateSchedule(userSeq, scheduleSeq,
             request);
         return ApiResponse.of(HttpStatus.OK, "해당 일정을 수정했습니다", response);
+
+    }
+
+    @PutMapping("/{scheduleSeq}/participation")
+    public ApiResponse<ParticipationUpdateResponse> updateParticipation(HttpServletRequest http,
+        @PathVariable Long scheduleSeq, @Valid @RequestBody ParticipationUpdateRequest request) {
+        log.info("PUT /api/schedule/{}/participation", scheduleSeq);
+        Long userSeq = tokenProvider.getUserSeq(http);
+        ParticipationUpdateResponse response = scheduleService.updateParticipation(userSeq,
+            scheduleSeq,
+            request);
+        return ApiResponse.of(HttpStatus.OK, "해당 일정의 참여자를 수정했습니다", response);
 
     }
 

--- a/backend/src/main/java/com/pppppp/amadda/schedule/dto/request/ParticipationUpdateRequest.java
+++ b/backend/src/main/java/com/pppppp/amadda/schedule/dto/request/ParticipationUpdateRequest.java
@@ -1,0 +1,16 @@
+package com.pppppp.amadda.schedule.dto.request;
+
+import com.pppppp.amadda.schedule.entity.AlarmTime;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+
+@Builder
+public record ParticipationUpdateRequest(
+    @NotNull(message = "알림 시간 설정이 필요해요!") AlarmTime alarmTime,
+    @NotBlank(message = "일정 이름을 입력해 주세요!") String scheduleName,
+    @NotNull(message = "유효하지 않은 요청입니다.") String scheduleMemo,
+    Long categorySeq
+) {
+
+}

--- a/backend/src/main/java/com/pppppp/amadda/schedule/dto/request/ScheduleUpdateRequest.java
+++ b/backend/src/main/java/com/pppppp/amadda/schedule/dto/request/ScheduleUpdateRequest.java
@@ -1,8 +1,6 @@
 package com.pppppp.amadda.schedule.dto.request;
 
-import com.pppppp.amadda.schedule.entity.AlarmTime;
 import com.pppppp.amadda.user.dto.response.UserReadResponse;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import lombok.Builder;
@@ -16,14 +14,7 @@ public record ScheduleUpdateRequest(
     @NotNull(message = "하루종일 지속되는 일정인지 알려주세요!") Boolean isAllDay,
     @NotNull(message = "유효하지 않은 요청입니다.") String scheduleStartAt,
     @NotNull(message = "유효하지 않은 요청입니다.") String scheduleEndAt,
-    @NotNull(message = "유효하지 않은 요청입니다.") List<UserReadResponse> participants,
-
-    // ================ Participation =================
-
-    @NotNull(message = "알림 시간 설정이 필요해요!") AlarmTime alarmTime,
-    @NotBlank(message = "일정 이름을 입력해 주세요!") String scheduleName,
-    @NotNull(message = "유효하지 않은 요청입니다.") String scheduleMemo,
-    Long categorySeq
+    @NotNull(message = "유효하지 않은 요청입니다.") List<UserReadResponse> participants
 ) {
 
 }

--- a/backend/src/main/java/com/pppppp/amadda/schedule/dto/response/ParticipationUpdateResponse.java
+++ b/backend/src/main/java/com/pppppp/amadda/schedule/dto/response/ParticipationUpdateResponse.java
@@ -1,0 +1,16 @@
+package com.pppppp.amadda.schedule.dto.response;
+
+import com.pppppp.amadda.schedule.entity.Participation;
+import lombok.Builder;
+
+@Builder
+public record ParticipationUpdateResponse(
+    Long scheduleId
+) {
+
+    public static ParticipationUpdateResponse of(Participation participation) {
+        return ParticipationUpdateResponse.builder()
+            .scheduleId(participation.getSchedule().getScheduleSeq())
+            .build();
+    }
+}

--- a/backend/src/main/java/com/pppppp/amadda/schedule/dto/response/ParticipationUpdateResponse.java
+++ b/backend/src/main/java/com/pppppp/amadda/schedule/dto/response/ParticipationUpdateResponse.java
@@ -5,12 +5,12 @@ import lombok.Builder;
 
 @Builder
 public record ParticipationUpdateResponse(
-    Long scheduleId
+    Long scheduleSeq
 ) {
 
     public static ParticipationUpdateResponse of(Participation participation) {
         return ParticipationUpdateResponse.builder()
-            .scheduleId(participation.getSchedule().getScheduleSeq())
+            .scheduleSeq(participation.getSchedule().getScheduleSeq())
             .build();
     }
 }

--- a/backend/src/main/java/com/pppppp/amadda/schedule/entity/Participation.java
+++ b/backend/src/main/java/com/pppppp/amadda/schedule/entity/Participation.java
@@ -1,8 +1,8 @@
 package com.pppppp.amadda.schedule.entity;
 
 import com.pppppp.amadda.global.entity.BaseEntity;
+import com.pppppp.amadda.schedule.dto.request.ParticipationUpdateRequest;
 import com.pppppp.amadda.schedule.dto.request.ScheduleCreateRequest;
-import com.pppppp.amadda.schedule.dto.request.ScheduleUpdateRequest;
 import com.pppppp.amadda.user.entity.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -87,7 +87,7 @@ public class Participation extends BaseEntity {
             .build();
     }
 
-    public void updateParticipationInfo(ScheduleUpdateRequest request) {
+    public void updateParticipationInfo(ParticipationUpdateRequest request) {
         this.scheduleName = request.scheduleName();
         this.scheduleMemo = request.scheduleMemo();
         this.alarmTime = request.alarmTime();

--- a/backend/src/main/java/com/pppppp/amadda/schedule/service/ScheduleService.java
+++ b/backend/src/main/java/com/pppppp/amadda/schedule/service/ScheduleService.java
@@ -397,11 +397,8 @@ public class ScheduleService {
             LocalDateTime.parse(request.scheduleStartAt()))) {
             return true;
         }
-        if (request.isTimeSelected() && !Objects.equals(schedule.getScheduleEndAt(),
-            LocalDateTime.parse(request.scheduleEndAt()))) {
-            return true;
-        }
-        return false;
+        return request.isTimeSelected() && !Objects.equals(schedule.getScheduleEndAt(),
+            LocalDateTime.parse(request.scheduleEndAt()));
     }
 
     private void createParticipation(Long userSeq, ScheduleCreateRequest request,

--- a/backend/src/main/java/com/pppppp/amadda/schedule/service/ScheduleService.java
+++ b/backend/src/main/java/com/pppppp/amadda/schedule/service/ScheduleService.java
@@ -10,12 +10,14 @@ import com.pppppp.amadda.global.entity.exception.errorcode.UserErrorCode;
 import com.pppppp.amadda.schedule.dto.request.CategoryCreateRequest;
 import com.pppppp.amadda.schedule.dto.request.CategoryUpdateRequest;
 import com.pppppp.amadda.schedule.dto.request.CommentCreateRequest;
+import com.pppppp.amadda.schedule.dto.request.ParticipationUpdateRequest;
 import com.pppppp.amadda.schedule.dto.request.ScheduleCreateRequest;
 import com.pppppp.amadda.schedule.dto.request.ScheduleUpdateRequest;
 import com.pppppp.amadda.schedule.dto.response.CategoryCreateResponse;
 import com.pppppp.amadda.schedule.dto.response.CategoryReadResponse;
 import com.pppppp.amadda.schedule.dto.response.CategoryUpdateResponse;
 import com.pppppp.amadda.schedule.dto.response.CommentReadResponse;
+import com.pppppp.amadda.schedule.dto.response.ParticipationUpdateResponse;
 import com.pppppp.amadda.schedule.dto.response.ScheduleCreateResponse;
 import com.pppppp.amadda.schedule.dto.response.ScheduleDetailReadResponse;
 import com.pppppp.amadda.schedule.dto.response.ScheduleListReadResponse;
@@ -221,23 +223,29 @@ public class ScheduleService {
         // 1. 전체 참가자에게 동기화되는 일정 정보 수정
         schedule.updateScheduleInfo(request);
 
-        // 2. 참가자 참석 정보 가져오기
-        Participation participation = findParticipationInfoBySchedule(scheduleSeq, userSeq);
-
-        // 3. 개인 참석 정보 수정
-        participation.updateParticipationInfo(request);
-
         // 4. 추가되는 사용자가 있으면 새롭게 참가자 추가, 없으면 참가자 목록 수정
         updateParticipantList(userSeq, request, schedule);
 
-        // 5. 생성자라면 카테고리 정보가 있는 경우 카테고리 정보 입력
+        return ScheduleUpdateResponse.of(schedule);
+    }
+
+    public ParticipationUpdateResponse updateParticipation(Long requestUserSeq, Long scheduleSeq,
+        ParticipationUpdateRequest request) {
+        findUserInfo(requestUserSeq);
+        Participation participation = findParticipationInfoBySchedule(scheduleSeq, requestUserSeq);
+
+        // 참가정보 수정
+        participation.updateParticipationInfo(request);
+
+        // 카테고리 정보가 있는 경우 카테고리 정보 입력
         if (request.categorySeq() != null) {
             participation.updateCategory(findCategoryInfo(request.categorySeq()));
         } else {
             participation.updateCategory(null);
         }
 
-        return ScheduleUpdateResponse.of(schedule);
+        // 결과 반환
+        return ParticipationUpdateResponse.of(participation);
     }
 
     @Transactional
@@ -582,15 +590,13 @@ public class ScheduleService {
             }
         }
 
-        // 4. 이전 사용자 목록과 비교해서 현재 사용자 중 추가된 사용자가 있는지 확인, 있으면 참석정보 생성.
+        // 이전 사용자 목록과 비교해서 현재 사용자 중 추가된 사용자가 있는지 확인, 있으면 참석정보 생성.
         Participation requestUserParticipation = findParticipationInfoBySchedule(
             schedule.getScheduleSeq(), requestUserSeq);
 
-        // 생성할 참석 정보는 이번 요청으로 수정되는 필드가 아니면 요청자의 참석정보를 기본값으로 사용
-        String scheduleName = (request.scheduleName() != null) ? request.scheduleName()
-            : requestUserParticipation.getScheduleName();
-        AlarmTime alarmTime = (request.alarmTime() != null) ? request.alarmTime()
-            : requestUserParticipation.getAlarmTime();
+        // 생성할 참석 정보는 요청자의 참석정보를 기본값으로 사용
+        String scheduleName = requestUserParticipation.getScheduleName();
+        AlarmTime alarmTime = requestUserParticipation.getAlarmTime();
         ScheduleCreateRequest createRequest = ScheduleCreateRequest.builder()
             .scheduleName(scheduleName)
             .alarmTime(alarmTime)
@@ -617,7 +623,7 @@ public class ScheduleService {
             alarmService.sendScheduleUpdate(schedule.getScheduleSeq(), user.getUserSeq());
         }
     }
-    
+
     private boolean isParticipationChanged(List<User> oldParticipations,
         List<User> newParticipations) {
         Set<User> oldSet = new HashSet<>(oldParticipations);

--- a/backend/src/test/java/com/pppppp/amadda/schedule/controller/ScheduleControllerTest.java
+++ b/backend/src/test/java/com/pppppp/amadda/schedule/controller/ScheduleControllerTest.java
@@ -592,32 +592,6 @@ class ScheduleControllerTest {
             .andExpect(jsonPath("$.message").value("알림 시간 설정이 필요해요!"));
     }
 
-    @DisplayName("참가정보 수정 시 일정 제목은 필수로 입력되어야 한다.")
-    @Test
-    void noScheduleNameToUpdate() throws Exception {
-
-        User user = User.create(1111L, "박동건", "icebearrrr", "imgUrl1");
-
-        ParticipationUpdateRequest request = ParticipationUpdateRequest.builder()
-            .scheduleMemo("수원역에서 걸어서 10분")
-            .alarmTime(AlarmTime.NONE)
-            .build();
-
-        // stubbing
-        when(scheduleService.updateSchedule(anyLong(), anyLong(),
-            any(ScheduleUpdateRequest.class)))
-            .thenReturn(ScheduleUpdateResponse.builder().scheduleSeq(1L).build());
-
-        mockMvc.perform(
-                put("/api/schedule/{scheduleSeq}/participation", 1L)
-                    .content(objectMapper.writeValueAsString(request))
-                    .contentType(MediaType.APPLICATION_JSON)
-            ).andDo(print())
-            .andExpect(status().isBadRequest())
-            .andExpect(jsonPath("$.code").value("400"))
-            .andExpect(jsonPath("$.message").value("일정 이름을 입력해 주세요!"));
-    }
-
     @DisplayName("일정 수정 시 날짜 확정 여부를 입력해야 한다.")
     @Test
     void noScheduleDateSelectedInfoToUpdate() throws Exception {
@@ -710,34 +684,49 @@ class ScheduleControllerTest {
             .andExpect(jsonPath("$.message").value("하루종일 지속되는 일정인지 알려주세요!"));
     }
 
-    @DisplayName("일정 수정 시 알림시간 설정은 필수다.")
+    @DisplayName("참가정보 수정 시 일정 제목은 필수로 입력되어야 한다.")
     @Test
-    void noScheduleAlarmTimeInfoToUpdate() throws Exception {
-        // given
-        User user = User.create(1111L, "박동건", "icebearrrr", "imgUrl1");
-
-        ScheduleCreateRequest request = ScheduleCreateRequest.builder()
-            // schedule
-            .scheduleContent("수원 시민 회관")
-            .isDateSelected(true)
-            .isTimeSelected(true)
-            .isAllDay(false)
-            .isAuthorizedAll(true)
-            .scheduleStartAt("2023-11-18 18:30:00")
-            .scheduleEndAt("2023-11-18 20:30:00")
-            .participants(List.of(UserReadResponse.of(user)))
-            // participation
-            .scheduleName("합창단 공연")
+    void noScheduleNameToUpdate() throws Exception {
+        ParticipationUpdateRequest request = ParticipationUpdateRequest.builder()
             .scheduleMemo("수원역에서 걸어서 10분")
+            .alarmTime(AlarmTime.NONE)
             .build();
 
-        // when  // then
+        // stubbing
+        when(scheduleService.updateSchedule(anyLong(), anyLong(),
+            any(ScheduleUpdateRequest.class)))
+            .thenReturn(ScheduleUpdateResponse.builder().scheduleSeq(1L).build());
+
         mockMvc.perform(
-                post("/api/schedule")
+                put("/api/schedule/{scheduleSeq}/participation", 1L)
                     .content(objectMapper.writeValueAsString(request))
                     .contentType(MediaType.APPLICATION_JSON)
             ).andDo(print())
             .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("400"))
+            .andExpect(jsonPath("$.message").value("일정 이름을 입력해 주세요!"));
+    }
+
+    @DisplayName("참가정보 수정 시 알림시간 설정은 필수다.")
+    @Test
+    void noScheduleAlarmTimeInfoToUpdate() throws Exception {
+        ParticipationUpdateRequest request = ParticipationUpdateRequest.builder()
+            .scheduleName("합창단 공연")
+            .scheduleMemo("수원역에서 걸어서 10분")
+            .build();
+
+        // stubbing
+        when(scheduleService.updateSchedule(anyLong(), anyLong(),
+            any(ScheduleUpdateRequest.class)))
+            .thenReturn(ScheduleUpdateResponse.builder().scheduleSeq(1L).build());
+
+        mockMvc.perform(
+                put("/api/schedule/{scheduleSeq}/participation", 1L)
+                    .content(objectMapper.writeValueAsString(request))
+                    .contentType(MediaType.APPLICATION_JSON)
+            ).andDo(print())
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("400"))
             .andExpect(jsonPath("$.message").value("알림 시간 설정이 필요해요!"));
     }
 

--- a/backend/src/test/java/com/pppppp/amadda/schedule/controller/ScheduleControllerTest.java
+++ b/backend/src/test/java/com/pppppp/amadda/schedule/controller/ScheduleControllerTest.java
@@ -18,9 +18,11 @@ import com.pppppp.amadda.global.util.TokenProvider;
 import com.pppppp.amadda.schedule.dto.request.CategoryCreateRequest;
 import com.pppppp.amadda.schedule.dto.request.CategoryUpdateRequest;
 import com.pppppp.amadda.schedule.dto.request.CommentCreateRequest;
+import com.pppppp.amadda.schedule.dto.request.ParticipationUpdateRequest;
 import com.pppppp.amadda.schedule.dto.request.ScheduleCreateRequest;
 import com.pppppp.amadda.schedule.dto.request.ScheduleUpdateRequest;
 import com.pppppp.amadda.schedule.dto.response.CategoryUpdateResponse;
+import com.pppppp.amadda.schedule.dto.response.ParticipationUpdateResponse;
 import com.pppppp.amadda.schedule.dto.response.ScheduleCreateResponse;
 import com.pppppp.amadda.schedule.dto.response.ScheduleUpdateResponse;
 import com.pppppp.amadda.schedule.entity.AlarmTime;
@@ -235,17 +237,14 @@ class ScheduleControllerTest {
             .andExpect(jsonPath("$.data").isArray());
     }
 
-    @DisplayName("일정을 수정한다.")
-    @ParameterizedTest
-    @ValueSource(strings = {"ONE_DAY_BEFORE", "ONE_HOUR_BEFORE", "THIRTY_MINUTE_BEFORE",
-        "FIFTEEN_MINUTE_BEFORE", "ON_TIME", "NONE"})
-    void updateSchedule(String alarmTime) throws Exception {
+    @DisplayName("일정의 동기화 부분을 수정한다.")
+    @Test
+    void updateSchedule() throws Exception {
         User user = User.create(111L, "박동건", "icebearrrr", "imgUrl1");
         Long scheduleSeq = 123L;
 
         ScheduleUpdateRequest request = ScheduleUpdateRequest.builder()
             // schedule
-            .scheduleName("합창단 공연")
             .scheduleContent("수원 시민 회관")
             .isDateSelected(true)
             .isTimeSelected(true)
@@ -254,9 +253,6 @@ class ScheduleControllerTest {
             .scheduleEndAt("2023-11-18 20:30:00")
             .participants(
                 List.of(UserReadResponse.of(user)))
-            // participation
-            .scheduleMemo("수원역에서 걸어서 10분")
-            .alarmTime(AlarmTime.valueOf(alarmTime))
             .build();
 
         // stubbing
@@ -267,6 +263,33 @@ class ScheduleControllerTest {
         mockMvc.perform(put("/api/schedule/{scheduleSeq}", scheduleSeq)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.code").value("200"));
+    }
+
+    @DisplayName("일정의 비동기화 부분을 수정한다.")
+    @ParameterizedTest
+    @ValueSource(strings = {"ONE_DAY_BEFORE", "ONE_HOUR_BEFORE", "THIRTY_MINUTE_BEFORE",
+        "FIFTEEN_MINUTE_BEFORE", "ON_TIME", "NONE"})
+    void updateParticipation(String alarmTime) throws Exception {
+        Long scheduleSeq = 123L;
+        Long categorySeq = 1L;
+
+        ParticipationUpdateRequest request = ParticipationUpdateRequest.builder()
+            .scheduleName("합창단 공연")
+            .scheduleMemo("수원역에서 걸어서 10분")
+            .alarmTime(AlarmTime.valueOf(alarmTime))
+            .build();
+
+        // stubbing
+        when(scheduleService.updateParticipation(anyLong(), anyLong(),
+            any(ParticipationUpdateRequest.class)))
+            .thenReturn(ParticipationUpdateResponse.builder().scheduleSeq(scheduleSeq).build());
+
+        mockMvc.perform(
+                put("/api/schedule/{scheduleSeq}/participation", scheduleSeq, categorySeq)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.code").value("200"));
     }
@@ -569,24 +592,15 @@ class ScheduleControllerTest {
             .andExpect(jsonPath("$.message").value("알림 시간 설정이 필요해요!"));
     }
 
-    @DisplayName("일정 수정 시 일정 제목은 필수로 입력되어야 한다.")
+    @DisplayName("참가정보 수정 시 일정 제목은 필수로 입력되어야 한다.")
     @Test
     void noScheduleNameToUpdate() throws Exception {
 
         User user = User.create(1111L, "박동건", "icebearrrr", "imgUrl1");
 
-        ScheduleUpdateRequest request = ScheduleUpdateRequest.builder()
-            // schedule
-            .scheduleContent("수원 시민 회관")
-            .isDateSelected(true)
-            .isTimeSelected(true)
-            .isAllDay(false)
-            .scheduleStartAt("2023-11-18 18:30:00")
-            .scheduleEndAt("2023-11-18 20:30:00")
-            .participants(List.of(UserReadResponse.of(user)))
-            // participation
+        ParticipationUpdateRequest request = ParticipationUpdateRequest.builder()
             .scheduleMemo("수원역에서 걸어서 10분")
-            .alarmTime(AlarmTime.ONE_DAY_BEFORE)
+            .alarmTime(AlarmTime.NONE)
             .build();
 
         // stubbing
@@ -595,7 +609,7 @@ class ScheduleControllerTest {
             .thenReturn(ScheduleUpdateResponse.builder().scheduleSeq(1L).build());
 
         mockMvc.perform(
-                put("/api/schedule/{scheduleSeq}", 1L)
+                put("/api/schedule/{scheduleSeq}/participation", 1L)
                     .content(objectMapper.writeValueAsString(request))
                     .contentType(MediaType.APPLICATION_JSON)
             ).andDo(print())
@@ -618,10 +632,6 @@ class ScheduleControllerTest {
             .scheduleStartAt("2023-11-18 18:30:00")
             .scheduleEndAt("2023-11-18 20:30:00")
             .participants(List.of(UserReadResponse.of(user)))
-            // participation
-            .scheduleName("합창단 공연")
-            .scheduleMemo("수원역에서 걸어서 10분")
-            .alarmTime(AlarmTime.ONE_DAY_BEFORE)
             .build();
 
         // stubbing
@@ -652,10 +662,6 @@ class ScheduleControllerTest {
             .scheduleStartAt("2023-11-18 18:30:00")
             .scheduleEndAt("2023-11-18 20:30:00")
             .participants(List.of(UserReadResponse.of(user)))
-            // participation
-            .scheduleName("합창단 공연")
-            .scheduleMemo("수원역에서 걸어서 10분")
-            .alarmTime(AlarmTime.ONE_DAY_BEFORE)
             .build();
 
         // stubbing
@@ -687,10 +693,6 @@ class ScheduleControllerTest {
             .scheduleStartAt("2023-11-18 18:30:00")
             .scheduleEndAt("2023-11-18 20:30:00")
             .participants(List.of(UserReadResponse.of(user)))
-            // participation
-            .scheduleName("합창단 공연")
-            .scheduleMemo("수원역에서 걸어서 10분")
-            .alarmTime(AlarmTime.ONE_DAY_BEFORE)
             .build();
 
         // stubbing


### PR DESCRIPTION
## 개요
- `Schedule`에 포함되는 일정의 동기화 내용과 `Participation`에 포함되는 비동기화 부분을 분리하였습니다.
- 수정 시 해당하는 부분에 맞는 API를 호출해야 하고, 만약 두 부분이 모두 수정되면 PUT 요청을 2번 보내야 합니다.

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).