### PR TITLE
Feat: 일정 조회 시 종료 여부 전달

### DIFF
--- a/backend/src/main/java/com/pppppp/amadda/schedule/controller/ScheduleController.java
+++ b/backend/src/main/java/com/pppppp/amadda/schedule/controller/ScheduleController.java
@@ -20,7 +20,7 @@ import com.pppppp.amadda.schedule.service.ScheduleService;
 import com.pppppp.amadda.user.dto.response.UserReadResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -61,8 +61,8 @@ public class ScheduleController {
     @GetMapping("/serverTime")
     public ApiResponse<String> getServerTime() {
         log.info("GET /api/schedule/serverTime");
-        log.info("time: {}", scheduleService.getServerTime());
-        return ApiResponse.ok(scheduleService.getServerTime());
+        log.info("time: {}", scheduleService.getServerDate());
+        return ApiResponse.ok(scheduleService.getServerDate());
     }
 
     @GetMapping("/{scheduleSeq}")
@@ -71,10 +71,10 @@ public class ScheduleController {
         log.info("GET /api/schedule/" + scheduleSeq);
         Long userSeq = tokenProvider.getUserSeq(http);
 
-        LocalDateTime currentServerTime = LocalDateTime.parse(scheduleService.getServerTime());
+        LocalDate currentServerDate = LocalDate.parse(scheduleService.getServerDate());
 
         return ApiResponse.ok(
-            scheduleService.getScheduleDetail(scheduleSeq, userSeq, currentServerTime));
+            scheduleService.getScheduleDetail(scheduleSeq, userSeq, currentServerDate));
     }
 
     @GetMapping("")
@@ -90,7 +90,7 @@ public class ScheduleController {
             "GET /api/schedule?category={}&searchKey={}&unscheduled={}&year={}&month={}&day={}",
             categorySeqList, searchKey, unscheduled, year, month, day);
 
-        LocalDateTime currentServerTime = LocalDateTime.parse(scheduleService.getServerTime());
+        LocalDate currentServerTime = LocalDate.parse(scheduleService.getServerDate());
 
         Map<String, String> searchCondition = Map.of("categories", categorySeqList.orElse(""),
             "searchKey", searchKey.orElse(""), "unscheduled", unscheduled.orElse(""), "year",

--- a/backend/src/main/java/com/pppppp/amadda/schedule/controller/ScheduleController.java
+++ b/backend/src/main/java/com/pppppp/amadda/schedule/controller/ScheduleController.java
@@ -20,6 +20,7 @@ import com.pppppp.amadda.schedule.service.ScheduleService;
 import com.pppppp.amadda.user.dto.response.UserReadResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -69,7 +70,11 @@ public class ScheduleController {
         @PathVariable Long scheduleSeq) {
         log.info("GET /api/schedule/" + scheduleSeq);
         Long userSeq = tokenProvider.getUserSeq(http);
-        return ApiResponse.ok(scheduleService.getScheduleDetail(scheduleSeq, userSeq));
+
+        LocalDateTime currentServerTime = LocalDateTime.parse(scheduleService.getServerTime());
+
+        return ApiResponse.ok(
+            scheduleService.getScheduleDetail(scheduleSeq, userSeq, currentServerTime));
     }
 
     @GetMapping("")
@@ -85,11 +90,14 @@ public class ScheduleController {
             "GET /api/schedule?category={}&searchKey={}&unscheduled={}&year={}&month={}&day={}",
             categorySeqList, searchKey, unscheduled, year, month, day);
 
+        LocalDateTime currentServerTime = LocalDateTime.parse(scheduleService.getServerTime());
+
         Map<String, String> searchCondition = Map.of("categories", categorySeqList.orElse(""),
             "searchKey", searchKey.orElse(""), "unscheduled", unscheduled.orElse(""), "year",
             year.orElse(""), "month", month.orElse(""), "day", day.orElse(""));
         Long userSeq = tokenProvider.getUserSeq(http);
-        return ApiResponse.ok(scheduleService.getScheduleListByCondition(userSeq, searchCondition));
+        return ApiResponse.ok(scheduleService.getScheduleListByCondition(userSeq, searchCondition,
+            currentServerTime));
     }
 
     @GetMapping("/{scheduleSeq}/participation")

--- a/backend/src/main/java/com/pppppp/amadda/schedule/dto/response/ScheduleDetailReadResponse.java
+++ b/backend/src/main/java/com/pppppp/amadda/schedule/dto/response/ScheduleDetailReadResponse.java
@@ -18,6 +18,7 @@ public record ScheduleDetailReadResponse(
     String scheduleStartAt,
     String scheduleEndAt,
     List<UserReadResponse> participants,
+    Boolean isFinished,
 
     // ================ Participation =================
     String alarmTime,

--- a/backend/src/main/java/com/pppppp/amadda/schedule/dto/response/ScheduleDetailReadResponse.java
+++ b/backend/src/main/java/com/pppppp/amadda/schedule/dto/response/ScheduleDetailReadResponse.java
@@ -52,4 +52,27 @@ public record ScheduleDetailReadResponse(
             .comments(comments)
             .build();
     }
+
+    public static ScheduleDetailReadResponse of(Schedule schedule,
+        List<UserReadResponse> participants,
+        Participation participation, List<CommentReadResponse> comments, Boolean isFinished) {
+        return ScheduleDetailReadResponse.builder()
+            .scheduleSeq(schedule.getScheduleSeq())
+            .scheduleContent(schedule.getScheduleContent())
+            .isTimeSelected(schedule.isTimeSelected())
+            .isDateSelected(schedule.isDateSelected())
+            .isAllDay(schedule.isAllDay())
+            .isAuthorizedAll(schedule.isAuthorizedAll())
+            .scheduleStartAt(String.valueOf(schedule.getScheduleStartAt()))
+            .scheduleEndAt(String.valueOf(schedule.getScheduleEndAt()))
+            .participants(participants)
+            .isFinished(isFinished)
+            .alarmTime(participation.getAlarmTime().getContent())
+            .scheduleName(participation.getScheduleName())
+            .scheduleMemo(participation.getScheduleMemo())
+            .category((participation.getCategory() != null) ?
+                CategoryReadResponse.of(participation.getCategory()) : null)
+            .comments(comments)
+            .build();
+    }
 }

--- a/backend/src/main/java/com/pppppp/amadda/schedule/dto/response/ScheduleListReadResponse.java
+++ b/backend/src/main/java/com/pppppp/amadda/schedule/dto/response/ScheduleListReadResponse.java
@@ -53,4 +53,29 @@ public record ScheduleListReadResponse(
             .build();
     }
 
+    public static ScheduleListReadResponse of(Schedule schedule,
+        UserReadResponse authorizedUser, List<UserReadResponse> participants,
+        Participation participation, Boolean isFinished) {
+
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+        return ScheduleListReadResponse.builder()
+            .scheduleSeq(schedule.getScheduleSeq())
+            .isTimeSelected(schedule.isTimeSelected())
+            .isDateSelected(schedule.isDateSelected())
+            .isAllDay(schedule.isAllDay())
+            .scheduleStartAt(
+                (schedule.isDateSelected()) ? schedule.getScheduleStartAt().format(formatter) : "")
+            .scheduleEndAt(
+                (schedule.isTimeSelected()) ? schedule.getScheduleEndAt().format(formatter) : "")
+            .isAuthorizedAll(schedule.isAuthorizedAll())
+            .authorizedUser(authorizedUser)
+            .participants(participants)
+            .isFinished(isFinished)
+            .alarmTime(participation.getAlarmTime().getContent())
+            .scheduleName(participation.getScheduleName())
+            .category((participation.getCategory() != null) ?
+                CategoryReadResponse.of(participation.getCategory()) : null)
+            .build();
+    }
 }

--- a/backend/src/main/java/com/pppppp/amadda/schedule/dto/response/ScheduleListReadResponse.java
+++ b/backend/src/main/java/com/pppppp/amadda/schedule/dto/response/ScheduleListReadResponse.java
@@ -9,6 +9,7 @@ import lombok.Builder;
 
 @Builder
 public record ScheduleListReadResponse(
+    // ================= Schedule ===================
     Long scheduleSeq,
     Boolean isTimeSelected,
     Boolean isDateSelected,
@@ -18,6 +19,10 @@ public record ScheduleListReadResponse(
     Boolean isAuthorizedAll,
     UserReadResponse authorizedUser,
     List<UserReadResponse> participants,
+    Boolean isFinished,
+
+    // ================ Participation =================
+
     String alarmTime,
     String scheduleName,
     CategoryReadResponse category

--- a/backend/src/main/java/com/pppppp/amadda/schedule/service/ScheduleService.java
+++ b/backend/src/main/java/com/pppppp/amadda/schedule/service/ScheduleService.java
@@ -810,7 +810,7 @@ public class ScheduleService {
             && date.getMonthValue() == Integer.parseInt(month);
     }
 
-    public boolean checkScheduleInMonthCondition(Participation participation, String year,
+    private boolean checkScheduleInMonthCondition(Participation participation, String year,
         String month) {
         // 확인하려는 일정의 시작시점, 종료시점
         LocalDateTime scheduleStartAt = participation.getSchedule().getScheduleStartAt();

--- a/backend/src/main/java/com/pppppp/amadda/schedule/service/ScheduleService.java
+++ b/backend/src/main/java/com/pppppp/amadda/schedule/service/ScheduleService.java
@@ -73,7 +73,7 @@ public class ScheduleService {
 
     private final CategoryRepository categoryRepository;
 
-    public String getServerTime() {
+    public String getServerDate() {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
         return LocalDate.now().format(formatter);
     }
@@ -97,7 +97,7 @@ public class ScheduleService {
     }
 
     public ScheduleDetailReadResponse getScheduleDetail(Long scheduleSeq, Long userSeq,
-        LocalDateTime currentServerTime) {
+        LocalDate currentServerDate) {
         findUserInfo(userSeq);
         Schedule schedule = findScheduleInfo(scheduleSeq);
 
@@ -114,9 +114,10 @@ public class ScheduleService {
         Boolean isFinished = null;
         if (schedule.isDateSelected()) {
             if (schedule.isTimeSelected()) {
-                isFinished = schedule.getScheduleEndAt().isBefore(currentServerTime);
+                isFinished = schedule.getScheduleEndAt().isBefore(currentServerDate.atStartOfDay());
             } else {
-                isFinished = schedule.getScheduleStartAt().isBefore(currentServerTime);
+                isFinished = schedule.getScheduleStartAt()
+                    .isBefore(currentServerDate.atStartOfDay());
             }
         }
 
@@ -125,10 +126,10 @@ public class ScheduleService {
     }
 
     public Map<String, List<ScheduleListReadResponse>> getScheduleListByCondition(
-        Long userSeq, Map<String, String> searchCondition, LocalDateTime currentServerTime) {
+        Long userSeq, Map<String, String> searchCondition, LocalDate currentServerDate) {
         // 조회 조건에 따라 일정 목록 가져오기
         List<ScheduleListReadResponse> scheduleListByCondition =
-            findScheduleListBySearchCondition(userSeq, searchCondition, currentServerTime);
+            findScheduleListBySearchCondition(userSeq, searchCondition, currentServerDate);
 
         // 반환할 map 생성
         Map<String, List<ScheduleListReadResponse>> response = new HashMap<>(Map.of());
@@ -207,8 +208,8 @@ public class ScheduleService {
     }
 
     public List<ScheduleListReadResponse> getScheduleListBySearchCondition(Long userSeq,
-        Map<String, String> searchCondition, LocalDateTime currentServerTime) {
-        return findScheduleListBySearchCondition(userSeq, searchCondition, currentServerTime);
+        Map<String, String> searchCondition, LocalDate currentServerDate) {
+        return findScheduleListBySearchCondition(userSeq, searchCondition, currentServerDate);
     }
 
     public List<UserReadResponse> getParticipatingUserList(Long scheduleSeq) {
@@ -524,7 +525,7 @@ public class ScheduleService {
     }
 
     private ScheduleListReadResponse findScheduleByParticipation(
-        Participation participation, LocalDateTime currentServerTime) {
+        Participation participation, LocalDate currentServerDate) {
 
         // 1. 참가하는 일정
         Long scheduleSeq = participation.getSchedule().getScheduleSeq();
@@ -550,9 +551,10 @@ public class ScheduleService {
         if (schedule.isDateSelected()) {
             if (schedule.isTimeSelected()) {
                 isFinished = schedule.getScheduleEndAt()
-                    .isBefore(currentServerTime);
+                    .isBefore(currentServerDate.atStartOfDay());
             } else {
-                isFinished = schedule.getScheduleStartAt().isBefore(currentServerTime);
+                isFinished = schedule.getScheduleStartAt()
+                    .isBefore(currentServerDate.atStartOfDay());
             }
         }
         return ScheduleListReadResponse.of(schedule,
@@ -704,7 +706,7 @@ public class ScheduleService {
     }
 
     private List<ScheduleListReadResponse> findScheduleListBySearchCondition(Long userSeq,
-        Map<String, String> searchCondition, LocalDateTime currentServerTime) {
+        Map<String, String> searchCondition, LocalDate currentServerDate) {
         // 사용자 체크
         findUserInfo(userSeq);
 
@@ -773,7 +775,7 @@ public class ScheduleService {
                 }
                 return true;
             })
-            .map(participation -> findScheduleByParticipation(participation, currentServerTime))
+            .map(participation -> findScheduleByParticipation(participation, currentServerDate))
             .toList();
     }
 

--- a/backend/src/test/java/com/pppppp/amadda/schedule/controller/ScheduleControllerTest.java
+++ b/backend/src/test/java/com/pppppp/amadda/schedule/controller/ScheduleControllerTest.java
@@ -117,6 +117,11 @@ class ScheduleControllerTest {
     @DisplayName("사용자의 단일 일정을 조회한다.")
     @Test
     void getSchedule() throws Exception {
+        // stubbing
+        String currentTime = String.valueOf(LocalDateTime.now());
+        when(scheduleService.getServerTime())
+            .thenReturn(currentTime);
+
         mockMvc.perform(
                 get("/api/schedule/{scheduleSeq}", 1L)
                     .contentType(MediaType.APPLICATION_JSON)
@@ -128,6 +133,11 @@ class ScheduleControllerTest {
     @DisplayName("사용자의 전체 일정을 조회한다.")
     @Test
     void getAllScheduleList() throws Exception {
+        // stubbing
+        String currentTime = String.valueOf(LocalDateTime.now());
+        when(scheduleService.getServerTime())
+            .thenReturn(currentTime);
+
         mockMvc.perform(
                 get("/api/schedule")
                     .contentType(MediaType.APPLICATION_JSON)
@@ -140,6 +150,11 @@ class ScheduleControllerTest {
     @DisplayName("query string을 통해 입력받은 조건에 맞는 일정 목록을 조회한다.")
     @Test
     void getScheduleListByConditions() throws Exception {
+        // stubbing
+        String currentTime = String.valueOf(LocalDateTime.now());
+        when(scheduleService.getServerTime())
+            .thenReturn(currentTime);
+
         // given
         String categorySeqList = "1,2";
         String searchKey = "합창단";
@@ -165,6 +180,11 @@ class ScheduleControllerTest {
         // given
         String categorySeqList = "1,2";
 
+        // stubbing
+        String currentTime = String.valueOf(LocalDateTime.now());
+        when(scheduleService.getServerTime())
+            .thenReturn(currentTime);
+
         // when // then
         mockMvc.perform(
                 get("/api/schedule?category={}", categorySeqList)
@@ -181,6 +201,11 @@ class ScheduleControllerTest {
         // given
         String searchKey = "합창단";
 
+        // stubbing
+        String currentTime = String.valueOf(LocalDateTime.now());
+        when(scheduleService.getServerTime())
+            .thenReturn(currentTime);
+
         // when // then
         mockMvc.perform(
                 get("/api/schedule?searchKey={}", searchKey)
@@ -196,6 +221,11 @@ class ScheduleControllerTest {
     void getUnscheduledScheduleList() throws Exception {
         // given
         String unscheduled = "true";
+
+        // stubbing
+        String currentTime = String.valueOf(LocalDateTime.now());
+        when(scheduleService.getServerTime())
+            .thenReturn(currentTime);
 
         // when // then
         mockMvc.perform(
@@ -214,6 +244,11 @@ class ScheduleControllerTest {
         String year = "2023";
         String month = "11";
         String day = "18";
+
+        // stubbing
+        String currentTime = String.valueOf(LocalDateTime.now());
+        when(scheduleService.getServerTime())
+            .thenReturn(currentTime);
 
         // when // then
         mockMvc.perform(

--- a/backend/src/test/java/com/pppppp/amadda/schedule/controller/ScheduleControllerTest.java
+++ b/backend/src/test/java/com/pppppp/amadda/schedule/controller/ScheduleControllerTest.java
@@ -29,7 +29,7 @@ import com.pppppp.amadda.schedule.entity.AlarmTime;
 import com.pppppp.amadda.schedule.service.ScheduleService;
 import com.pppppp.amadda.user.dto.response.UserReadResponse;
 import com.pppppp.amadda.user.entity.User;
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -100,8 +100,8 @@ class ScheduleControllerTest {
     @Test
     void getServerTime() throws Exception {
         // stubbing
-        String currentTime = String.valueOf(LocalDateTime.now());
-        when(scheduleService.getServerTime())
+        String currentTime = String.valueOf(LocalDate.now());
+        when(scheduleService.getServerDate())
             .thenReturn(currentTime);
 
         // then
@@ -118,8 +118,8 @@ class ScheduleControllerTest {
     @Test
     void getSchedule() throws Exception {
         // stubbing
-        String currentTime = String.valueOf(LocalDateTime.now());
-        when(scheduleService.getServerTime())
+        String currentTime = String.valueOf(LocalDate.now());
+        when(scheduleService.getServerDate())
             .thenReturn(currentTime);
 
         mockMvc.perform(
@@ -134,8 +134,8 @@ class ScheduleControllerTest {
     @Test
     void getAllScheduleList() throws Exception {
         // stubbing
-        String currentTime = String.valueOf(LocalDateTime.now());
-        when(scheduleService.getServerTime())
+        String currentTime = String.valueOf(LocalDate.now());
+        when(scheduleService.getServerDate())
             .thenReturn(currentTime);
 
         mockMvc.perform(
@@ -151,8 +151,8 @@ class ScheduleControllerTest {
     @Test
     void getScheduleListByConditions() throws Exception {
         // stubbing
-        String currentTime = String.valueOf(LocalDateTime.now());
-        when(scheduleService.getServerTime())
+        String currentTime = String.valueOf(LocalDate.now());
+        when(scheduleService.getServerDate())
             .thenReturn(currentTime);
 
         // given
@@ -181,8 +181,8 @@ class ScheduleControllerTest {
         String categorySeqList = "1,2";
 
         // stubbing
-        String currentTime = String.valueOf(LocalDateTime.now());
-        when(scheduleService.getServerTime())
+        String currentTime = String.valueOf(LocalDate.now());
+        when(scheduleService.getServerDate())
             .thenReturn(currentTime);
 
         // when // then
@@ -202,8 +202,8 @@ class ScheduleControllerTest {
         String searchKey = "합창단";
 
         // stubbing
-        String currentTime = String.valueOf(LocalDateTime.now());
-        when(scheduleService.getServerTime())
+        String currentTime = String.valueOf(LocalDate.now());
+        when(scheduleService.getServerDate())
             .thenReturn(currentTime);
 
         // when // then
@@ -223,8 +223,8 @@ class ScheduleControllerTest {
         String unscheduled = "true";
 
         // stubbing
-        String currentTime = String.valueOf(LocalDateTime.now());
-        when(scheduleService.getServerTime())
+        String currentTime = String.valueOf(LocalDate.now());
+        when(scheduleService.getServerDate())
             .thenReturn(currentTime);
 
         // when // then
@@ -246,8 +246,8 @@ class ScheduleControllerTest {
         String day = "18";
 
         // stubbing
-        String currentTime = String.valueOf(LocalDateTime.now());
-        when(scheduleService.getServerTime())
+        String currentTime = String.valueOf(LocalDate.now());
+        when(scheduleService.getServerDate())
             .thenReturn(currentTime);
 
         // when // then

--- a/backend/src/test/java/com/pppppp/amadda/schedule/service/ScheduleServiceTest.java
+++ b/backend/src/test/java/com/pppppp/amadda/schedule/service/ScheduleServiceTest.java
@@ -48,6 +48,7 @@ import com.pppppp.amadda.user.repository.UserRepository;
 import jakarta.transaction.Transactional;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -136,10 +137,11 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .build();
 
         // when
+        LocalDateTime testServerTime = LocalDateTime.of(2021, 10, 31, 0, 0, 0);
         ScheduleCreateResponse response = scheduleService.createSchedule(u1.getUserSeq(),
             request);
         ScheduleDetailReadResponse schedule = scheduleService.getScheduleDetail(
-            response.scheduleSeq(), u1.getUserSeq());
+            response.scheduleSeq(), u1.getUserSeq(), testServerTime);
 
         // then
         assertThat(schedule).isNotNull()
@@ -186,10 +188,11 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .build();
 
         // when
+        LocalDateTime testServerTime = LocalDateTime.of(2021, 10, 31, 0, 0, 0);
         ScheduleCreateResponse response = scheduleService.createSchedule(u1.getUserSeq(),
             request);
         ScheduleDetailReadResponse schedule = scheduleService.getScheduleDetail(
-            response.scheduleSeq(), u1.getUserSeq());
+            response.scheduleSeq(), u1.getUserSeq(), testServerTime);
 
         // then
         assertThat(schedule).isNotNull()
@@ -236,10 +239,11 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .build();
 
         // when
+        LocalDateTime testServerTime = LocalDateTime.of(2021, 10, 31, 0, 0, 0);
         ScheduleCreateResponse response = scheduleService.createSchedule(u1.getUserSeq(),
             request);
         ScheduleDetailReadResponse schedule = scheduleService.getScheduleDetail(
-            response.scheduleSeq(), u1.getUserSeq());
+            response.scheduleSeq(), u1.getUserSeq(), testServerTime);
 
         // then
         assertThat(schedule).isNotNull()
@@ -286,10 +290,11 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .build();
 
         // when
+        LocalDateTime testServerTime = LocalDateTime.of(2021, 10, 31, 0, 0, 0);
         ScheduleCreateResponse response = scheduleService.createSchedule(u1.getUserSeq(),
             request);
         ScheduleDetailReadResponse schedule = scheduleService.getScheduleDetail(
-            response.scheduleSeq(), u1.getUserSeq());
+            response.scheduleSeq(), u1.getUserSeq(), testServerTime);
 
         // then
         assertThat(schedule).isNotNull()
@@ -320,7 +325,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
     @Test
     void getServerTime() {
         // given
-        String expectedFormat = "yyyy-MM-dd HH:mm:ss";
+        String expectedFormat = "yyyy-MM-dd";
 
         // when
         String serverTime = scheduleService.getServerTime();
@@ -372,16 +377,17 @@ class ScheduleServiceTest extends IntegrationTestSupport {
         scheduleService.createSchedule(u2.getUserSeq(), r2);
 
         // when
+        LocalDateTime testServerTime = LocalDateTime.of(2021, 10, 31, 0, 0, 0);
         Map<String, String> searchCondition = Map.of("categories", "", "searchKey", "",
             "unscheduled", "", "month", "", "day", "", "year", "");
         List<ScheduleListReadResponse> user1Schedules = scheduleService.getScheduleListBySearchCondition(
-            u1.getUserSeq(), searchCondition);
+            u1.getUserSeq(), searchCondition, testServerTime);
         List<ScheduleListReadResponse> user2Schedules = scheduleService.getScheduleListBySearchCondition(
-            u2.getUserSeq(), searchCondition);
+            u2.getUserSeq(), searchCondition, testServerTime);
         Map<String, List<ScheduleListReadResponse>> user1Result = scheduleService.getScheduleListByCondition(
-            u1.getUserSeq(), searchCondition);
+            u1.getUserSeq(), searchCondition, testServerTime);
         Map<String, List<ScheduleListReadResponse>> user2Result = scheduleService.getScheduleListByCondition(
-            u2.getUserSeq(), searchCondition);
+            u2.getUserSeq(), searchCondition, testServerTime);
 
         // then
         assertThat(user1Schedules)
@@ -431,10 +437,11 @@ class ScheduleServiceTest extends IntegrationTestSupport {
         ScheduleCreateResponse createResponse = scheduleService.createSchedule(u1.getUserSeq(), r1);
 
         // when
+        LocalDateTime testServerTime = LocalDateTime.of(2021, 10, 31, 0, 0, 0);
         ScheduleDetailReadResponse u1Response = scheduleService.getScheduleDetail(
-            createResponse.scheduleSeq(), u1.getUserSeq());
+            createResponse.scheduleSeq(), u1.getUserSeq(), testServerTime);
         ScheduleDetailReadResponse u2Response = scheduleService.getScheduleDetail(
-            createResponse.scheduleSeq(), u2.getUserSeq());
+            createResponse.scheduleSeq(), u2.getUserSeq(), testServerTime);
 
         // then
         assertThat(u1Response).isNotNull();
@@ -499,14 +506,15 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             String.valueOf(categories.get(0).getCategorySeq()), "searchKey", "", "unscheduled", "",
             "month", "", "day", "", "year", "");
 
+        LocalDateTime testServerTime = LocalDateTime.of(2021, 10, 31, 0, 0, 0);
         List<ScheduleListReadResponse> result1 = scheduleService.getScheduleListBySearchCondition(
-            u1.getUserSeq(), searchCondition1);
+            u1.getUserSeq(), searchCondition1, testServerTime);
         List<ScheduleListReadResponse> result2 = scheduleService.getScheduleListBySearchCondition(
-            u1.getUserSeq(), searchCondition2);
+            u1.getUserSeq(), searchCondition2, testServerTime);
         Map<String, List<ScheduleListReadResponse>> mapResult1 = scheduleService.getScheduleListByCondition(
-            u1.getUserSeq(), searchCondition1);
+            u1.getUserSeq(), searchCondition1, testServerTime);
         Map<String, List<ScheduleListReadResponse>> mapResult2 = scheduleService.getScheduleListByCondition(
-            u1.getUserSeq(), searchCondition2);
+            u1.getUserSeq(), searchCondition2, testServerTime);
 
         // then
         assertThat(result1)
@@ -572,12 +580,13 @@ class ScheduleServiceTest extends IntegrationTestSupport {
         scheduleService.createSchedule(u1.getUserSeq(), r2);
 
         // when
+        LocalDateTime testServerTime = LocalDateTime.of(2021, 10, 31, 0, 0, 0);
         Map<String, String> searchCondition = Map.of("searchKey", "일정", "unscheduled", "",
             "categories", "", "month", "", "day", "", "year", "");
         List<ScheduleListReadResponse> schedules = scheduleService.getScheduleListBySearchCondition(
-            u1.getUserSeq(), searchCondition);
+            u1.getUserSeq(), searchCondition, testServerTime);
         Map<String, List<ScheduleListReadResponse>> mapResult = scheduleService.getScheduleListByCondition(
-            u1.getUserSeq(), searchCondition);
+            u1.getUserSeq(), searchCondition, testServerTime);
 
         // then
         assertThat(schedules)
@@ -630,12 +639,13 @@ class ScheduleServiceTest extends IntegrationTestSupport {
         scheduleService.createSchedule(u1.getUserSeq(), r2);
 
         // when
+        LocalDateTime testServerTime = LocalDateTime.of(2021, 10, 31, 0, 0, 0);
         Map<String, String> searchCondition = Map.of("categories", "", "searchKey", "",
             "unscheduled", "true", "month", "", "day", "", "year", "");
         List<ScheduleListReadResponse> result = scheduleService.getScheduleListBySearchCondition(
-            u1.getUserSeq(), searchCondition);
+            u1.getUserSeq(), searchCondition, testServerTime);
         Map<String, List<ScheduleListReadResponse>> mapResult = scheduleService.getScheduleListByCondition(
-            u1.getUserSeq(), searchCondition);
+            u1.getUserSeq(), searchCondition, testServerTime);
 
         // then
         assertThat(result)
@@ -736,16 +746,17 @@ class ScheduleServiceTest extends IntegrationTestSupport {
         scheduleService.createSchedule(u1.getUserSeq(), r6);
 
         // when
+        LocalDateTime testServerTime = LocalDateTime.of(2023, 11, 1, 9, 0, 0);
         Map<String, String> searchCondition = Map.of("categories", "", "searchKey", "",
             "unscheduled", "", "month", "11", "day", "", "year", "2023");
         List<ScheduleListReadResponse> result1 = scheduleService.getScheduleListBySearchCondition(
-            u1.getUserSeq(), searchCondition);
+            u1.getUserSeq(), searchCondition, testServerTime);
         List<ScheduleListReadResponse> result2 = scheduleService.getScheduleListBySearchCondition(
-            u2.getUserSeq(), searchCondition);
+            u2.getUserSeq(), searchCondition, testServerTime);
         Map<String, List<ScheduleListReadResponse>> mapResult1 = scheduleService.getScheduleListByCondition(
-            u1.getUserSeq(), searchCondition);
+            u1.getUserSeq(), searchCondition, testServerTime);
         Map<String, List<ScheduleListReadResponse>> mapResult2 = scheduleService.getScheduleListByCondition(
-            u2.getUserSeq(), searchCondition);
+            u2.getUserSeq(), searchCondition, testServerTime);
 
         // then
         assertThat(result1)
@@ -778,6 +789,134 @@ class ScheduleServiceTest extends IntegrationTestSupport {
         assertThat(mapResult2)
             .hasSize(1)
             .containsKeys("2023-11-01");
+    }
+
+    @DisplayName("사용자의 이번달 일정 목록을 조회한다. 그 중 현재 시점에서 이전 일정은 종료되었다고 표시한다.")
+    @Transactional
+    @Test
+    void getScheduleListByMonthWithIsFinished() {
+        // given
+        User u1 = userRepository.findAll().get(0);
+        User u2 = userRepository.findAll().get(1);
+
+        ScheduleCreateRequest r1 = ScheduleCreateRequest.builder()
+            .scheduleName("안녕 내가 일정 이름이야")
+            .isTimeSelected(true)
+            .isDateSelected(true)
+            .isAllDay(false)
+            .scheduleStartAt("2023-10-01 08:59:30")
+            .scheduleEndAt("2023-11-01 09:00:00")
+            .isAuthorizedAll(false)
+            .alarmTime(AlarmTime.NONE)
+            .participants(List.of(
+                UserReadResponse.of(u1)))
+            .build();
+        ScheduleCreateRequest r2 = ScheduleCreateRequest.builder()
+            .scheduleName("나도 일정이야")
+            .isTimeSelected(true)
+            .isDateSelected(true)
+            .isAllDay(false)
+            .scheduleStartAt("2023-11-01 08:59:30")
+            .scheduleEndAt("2023-11-01 09:00:00")
+            .isAuthorizedAll(false)
+            .alarmTime(AlarmTime.ON_TIME)
+            .participants(List.of(UserReadResponse.of(u1), UserReadResponse.of(u2)))
+            .build();
+        ScheduleCreateRequest r3 = ScheduleCreateRequest.builder()
+            .scheduleName("나도 일정이야")
+            .isTimeSelected(true)
+            .isDateSelected(true)
+            .isAllDay(false)
+            .scheduleStartAt("2023-10-30 08:59:30")
+            .scheduleEndAt("2023-10-30 09:00:00")
+            .isAuthorizedAll(false)
+            .alarmTime(AlarmTime.ON_TIME)
+            .participants(List.of(UserReadResponse.of(u1), UserReadResponse.of(u2)))
+            .build();
+        ScheduleCreateRequest r4 = ScheduleCreateRequest.builder()
+            .scheduleName("나도 일정이야")
+            .isTimeSelected(true)
+            .isDateSelected(true)
+            .isAllDay(false)
+            .scheduleStartAt("2023-11-30 08:59:30")
+            .scheduleEndAt("2023-12-01 09:00:00")
+            .isAuthorizedAll(false)
+            .alarmTime(AlarmTime.ON_TIME)
+            .participants(List.of(UserReadResponse.of(u1)))
+            .build();
+        ScheduleCreateRequest r5 = ScheduleCreateRequest.builder()
+            .scheduleName("나도 일정이야")
+            .isTimeSelected(false)
+            .isDateSelected(true)
+            .isAllDay(false)
+            .scheduleStartAt("2023-11-30 00:00:00")
+            .isAuthorizedAll(false)
+            .alarmTime(AlarmTime.ON_TIME)
+            .participants(List.of(UserReadResponse.of(u2)))
+            .build();
+        ScheduleCreateRequest r6 = ScheduleCreateRequest.builder()
+            .scheduleName("나도 일정이야")
+            .isTimeSelected(true)
+            .isDateSelected(true)
+            .isAllDay(false)
+            .scheduleStartAt("2023-10-30 08:59:30")
+            .scheduleEndAt("2023-12-01 09:00:00")
+            .isAuthorizedAll(false)
+            .alarmTime(AlarmTime.ON_TIME)
+            .participants(List.of(UserReadResponse.of(u1)))
+            .build();
+        scheduleService.createSchedule(u1.getUserSeq(), r1);
+        scheduleService.createSchedule(u1.getUserSeq(), r2);
+        scheduleService.createSchedule(u1.getUserSeq(), r3);
+        scheduleService.createSchedule(u1.getUserSeq(), r4);
+        scheduleService.createSchedule(u2.getUserSeq(), r5);
+        scheduleService.createSchedule(u1.getUserSeq(), r6);
+
+        // when
+        LocalDateTime testServerTime = LocalDateTime.of(2023, 11, 15, 0, 0, 0);
+        Map<String, String> searchCondition = Map.of("categories", "", "searchKey", "",
+            "unscheduled", "", "month", "11", "day", "", "year", "2023");
+        List<ScheduleListReadResponse> result1 = scheduleService.getScheduleListBySearchCondition(
+            u1.getUserSeq(), searchCondition, testServerTime);
+        List<ScheduleListReadResponse> result2 = scheduleService.getScheduleListBySearchCondition(
+            u2.getUserSeq(), searchCondition, testServerTime);
+        Map<String, List<ScheduleListReadResponse>> mapResult1 = scheduleService.getScheduleListByCondition(
+            u1.getUserSeq(), searchCondition, testServerTime);
+        Map<String, List<ScheduleListReadResponse>> mapResult2 = scheduleService.getScheduleListByCondition(
+            u2.getUserSeq(), searchCondition, testServerTime);
+
+        // then
+        assertThat(result1)
+            .hasSize(4)
+            .extracting("scheduleStartAt", "scheduleEndAt", "isFinished")
+            .containsExactlyInAnyOrder(
+                tuple("2023-10-01 08:59:30", "2023-11-01 09:00:00", true),
+                tuple("2023-11-01 08:59:30", "2023-11-01 09:00:00", true),
+                tuple("2023-11-30 08:59:30", "2023-12-01 09:00:00", false),
+                tuple("2023-10-30 08:59:30", "2023-12-01 09:00:00", false)
+            );
+        assertThat(result2)
+            .hasSize(2)
+            .extracting("scheduleStartAt", "scheduleEndAt", "isFinished")
+            .containsExactlyInAnyOrder(
+                tuple("2023-11-01 08:59:30", "2023-11-01 09:00:00", true),
+                tuple("2023-11-30 00:00:00", "", false)
+            );
+
+        assertThat(mapResult1)
+            .hasSize(30)
+            // 2023년 11월 1일부터 2023년 11월 30일까지 다 포함
+            .containsKeys("2023-11-01", "2023-11-02", "2023-11-03", "2023-11-04",
+                "2023-11-05",
+                "2023-11-06", "2023-11-07", "2023-11-08", "2023-11-09", "2023-11-10", "2023-11-11",
+                "2023-11-12", "2023-11-13", "2023-11-14", "2023-11-15", "2023-11-16", "2023-11-17",
+                "2023-11-18", "2023-11-19", "2023-11-20", "2023-11-21", "2023-11-22", "2023-11-23",
+                "2023-11-24", "2023-11-25", "2023-11-26", "2023-11-27", "2023-11-28", "2023-11-29",
+                "2023-11-30");
+
+        assertThat(mapResult2)
+            .hasSize(2)
+            .containsKeys("2023-11-01", "2023-11-30");
     }
 
     @DisplayName("사용자의 오늘 일정 목록을 조회한다.")
@@ -851,16 +990,17 @@ class ScheduleServiceTest extends IntegrationTestSupport {
         scheduleService.createSchedule(u2.getUserSeq(), r5);
 
         // when
+        LocalDateTime testServerTime = LocalDateTime.of(2023, 11, 1, 9, 0, 0);
         Map<String, String> searchCondition = Map.of("categories", "", "searchKey", "",
             "unscheduled", "", "month", "11", "day", "1", "year", "2023");
         List<ScheduleListReadResponse> result1 = scheduleService.getScheduleListBySearchCondition(
-            u1.getUserSeq(), searchCondition);
+            u1.getUserSeq(), searchCondition, testServerTime);
         List<ScheduleListReadResponse> result2 = scheduleService.getScheduleListBySearchCondition(
-            u2.getUserSeq(), searchCondition);
+            u2.getUserSeq(), searchCondition, testServerTime);
         Map<String, List<ScheduleListReadResponse>> mapResult1 = scheduleService.getScheduleListByCondition(
-            u1.getUserSeq(), searchCondition);
+            u1.getUserSeq(), searchCondition, testServerTime);
         Map<String, List<ScheduleListReadResponse>> mapResult2 = scheduleService.getScheduleListByCondition(
-            u2.getUserSeq(), searchCondition);
+            u2.getUserSeq(), searchCondition, testServerTime);
 
         // then
         assertThat(result1)
@@ -957,15 +1097,16 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .build();
 
         // when
+        LocalDateTime testServerTime = LocalDateTime.of(2021, 10, 31, 0, 0, 0);
         scheduleService.updateSchedule(
             u1.getUserSeq(), schedule.scheduleSeq(), scheduleUpdateRequest);
 
         ScheduleDetailReadResponse response1 = scheduleService.getScheduleDetail(
             schedule.scheduleSeq(),
-            u1.getUserSeq());
+            u1.getUserSeq(), testServerTime);
         ScheduleDetailReadResponse response2 = scheduleService.getScheduleDetail(
             schedule.scheduleSeq(),
-            u2.getUserSeq());
+            u2.getUserSeq(), testServerTime);
 
         // then
         assertThat(response1.scheduleSeq()).isEqualTo(response2.scheduleSeq());
@@ -1017,14 +1158,15 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .build();
 
         // when
+        LocalDateTime testServerTime = LocalDateTime.of(2021, 10, 31, 0, 0, 0);
         ScheduleUpdateResponse updateResponse = scheduleService.updateSchedule(
             u2.getUserSeq(), createResponse.scheduleSeq(), scheduleUpdateRequest);
         ScheduleDetailReadResponse response1 = scheduleService.getScheduleDetail(
             updateResponse.scheduleSeq(),
-            u1.getUserSeq());
+            u1.getUserSeq(), testServerTime);
         ScheduleDetailReadResponse response2 = scheduleService.getScheduleDetail(
             updateResponse.scheduleSeq(),
-            u3.getUserSeq());
+            u3.getUserSeq(), testServerTime);
 
         // then
         assertThat(response2).isNotNull();
@@ -1156,11 +1298,14 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             u1.getUserSeq(),
             schedule.scheduleSeq(),
             updateRequest);
+
+        LocalDateTime testServerTime = LocalDateTime.of(2021, 10, 31, 0, 0, 0);
         Optional<Participation> result1 = participationRepository.findBySchedule_ScheduleSeqAndUser_UserSeqAndIsDeletedFalse(
             updateResponse.scheduleSeq(), u1.getUserSeq());
         List<ScheduleListReadResponse> result2 = scheduleService.getScheduleListBySearchCondition(
             u1.getUserSeq(), Map.of("categories", String.valueOf(category.getCategorySeq()),
-                "searchKey", "", "unscheduled", "", "month", "", "day", "", "year", ""));
+                "searchKey", "", "unscheduled", "", "month", "", "day", "", "year", ""),
+            testServerTime);
 
         // then
         assertThat(result1).isPresent();
@@ -1219,12 +1364,15 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             u1.getUserSeq(),
             s1.scheduleSeq(),
             updateRequest);
+
+        LocalDateTime testServerTime = LocalDateTime.of(2021, 10, 31, 0, 0, 0);
         List<ScheduleListReadResponse> result = scheduleService.getScheduleListBySearchCondition(
             u1.getUserSeq(), Map.of("categories", String.valueOf(category.getCategorySeq()),
-                "searchKey", "", "unscheduled", "", "month", "", "day", "", "year", ""));
+                "searchKey", "", "unscheduled", "", "month", "", "day", "", "year", ""),
+            testServerTime);
         ScheduleDetailReadResponse result2 = scheduleService.getScheduleDetail(
             updateResponse.scheduleSeq(),
-            u1.getUserSeq());
+            u1.getUserSeq(), testServerTime);
 
         // then
         assertThat(result).hasSize(1)
@@ -1340,8 +1488,9 @@ class ScheduleServiceTest extends IntegrationTestSupport {
         scheduleService.createCommentOnSchedule(
             schedule.scheduleSeq(), user.getUserSeq(), CommentCreateRequest.of("세상에서 제일 불행한 사람임"));
 
+        LocalDateTime testServerTime = LocalDateTime.of(2021, 10, 31, 0, 0, 0);
         CommentReadResponse response = scheduleService.getScheduleDetail(schedule.scheduleSeq(),
-            user.getUserSeq()).comments().get(0);
+            user.getUserSeq(), testServerTime).comments().get(0);
 
         // then
         assertThat(response).isNotNull()
@@ -1370,14 +1519,15 @@ class ScheduleServiceTest extends IntegrationTestSupport {
         ScheduleCreateResponse schedule = scheduleService.createSchedule(user.getUserSeq(),
             request);
 
+        LocalDateTime testServerTime = LocalDateTime.of(2021, 10, 31, 0, 0, 0);
         scheduleService.createCommentOnSchedule(
             schedule.scheduleSeq(), user.getUserSeq(), CommentCreateRequest.of("세상에서 제일 불행한 사람임"));
         CommentReadResponse r1 = scheduleService.getScheduleDetail(schedule.scheduleSeq(),
-            user.getUserSeq()).comments().get(0);
+            user.getUserSeq(), testServerTime).comments().get(0);
         scheduleService.createCommentOnSchedule(schedule.scheduleSeq(),
             user.getUserSeq(), CommentCreateRequest.of("얘는 삭제될거임"));
         CommentReadResponse r2 = scheduleService.getScheduleDetail(schedule.scheduleSeq(),
-            user.getUserSeq()).comments().get(1);
+            user.getUserSeq(), testServerTime).comments().get(1);
 
         // when
         scheduleService.deleteComment(r2.commentSeq(), user.getUserSeq());
@@ -1564,7 +1714,9 @@ class ScheduleServiceTest extends IntegrationTestSupport {
         Long scheduleSeq = 3L;
         User user = userRepository.findAll().get(0);
 
-        assertThatThrownBy(() -> scheduleService.getScheduleDetail(scheduleSeq, user.getUserSeq()))
+        LocalDateTime testServerTime = LocalDateTime.of(2021, 10, 31, 0, 0, 0);
+        assertThatThrownBy(
+            () -> scheduleService.getScheduleDetail(scheduleSeq, user.getUserSeq(), testServerTime))
             .isInstanceOf(RestApiException.class)
             .hasMessage("SCHEDULE_NOT_FOUND");
     }
@@ -1871,8 +2023,10 @@ class ScheduleServiceTest extends IntegrationTestSupport {
 
         scheduleService.createCommentOnSchedule(
             s.getScheduleSeq(), user.getUserSeq(), CommentCreateRequest.of("세상에서 제일 불행한 사람임"));
+
+        LocalDateTime testServerTime = LocalDateTime.of(2021, 10, 31, 0, 0, 0);
         CommentReadResponse response = scheduleService.getScheduleDetail(s.getScheduleSeq(),
-            user.getUserSeq()).comments().get(0);
+            user.getUserSeq(), testServerTime).comments().get(0);
 
         // when // then
         assertThatThrownBy(
@@ -1906,8 +2060,9 @@ class ScheduleServiceTest extends IntegrationTestSupport {
         scheduleService.createCommentOnSchedule(
             s.getScheduleSeq(), u1.getUserSeq(), CommentCreateRequest.of("세상에서 제일 불행한 사람임"));
 
+        LocalDateTime testServerTime = LocalDateTime.of(2021, 10, 31, 0, 0, 0);
         CommentReadResponse response = scheduleService.getScheduleDetail(s.getScheduleSeq(),
-            u1.getUserSeq()).comments().get(0);
+            u1.getUserSeq(), testServerTime).comments().get(0);
 
         // when // then
         assertThatThrownBy(
@@ -2004,10 +2159,11 @@ class ScheduleServiceTest extends IntegrationTestSupport {
         // when
         Map<String, String> searchCondition = Map.of("categories", "", "searchKey", "",
             "unscheduled", "", "month", "11", "day", "1", "year", "");
+        LocalDateTime testServerTime = LocalDateTime.of(2021, 10, 31, 0, 0, 0);
 
         // then
         assertThatThrownBy(() -> scheduleService.getScheduleListBySearchCondition(
-            u1.getUserSeq(), searchCondition))
+            u1.getUserSeq(), searchCondition, testServerTime))
             .isInstanceOf(RestApiException.class)
             .hasMessage("SCHEDULE_INVALID_REQUEST");
     }
@@ -2085,10 +2241,11 @@ class ScheduleServiceTest extends IntegrationTestSupport {
         // when
         Map<String, String> searchCondition = Map.of("categories", "", "searchKey", "",
             "unscheduled", "", "month", "", "day", "1", "year", "2023");
+        LocalDateTime testServerTime = LocalDateTime.of(2021, 10, 31, 0, 0, 0);
 
         // then
         assertThatThrownBy(() -> scheduleService.getScheduleListBySearchCondition(
-            u1.getUserSeq(), searchCondition))
+            u1.getUserSeq(), searchCondition, testServerTime))
             .isInstanceOf(RestApiException.class)
             .hasMessage("SCHEDULE_INVALID_REQUEST");
     }

--- a/backend/src/test/java/com/pppppp/amadda/schedule/service/ScheduleServiceTest.java
+++ b/backend/src/test/java/com/pppppp/amadda/schedule/service/ScheduleServiceTest.java
@@ -48,7 +48,7 @@ import com.pppppp.amadda.user.repository.UserRepository;
 import jakarta.transaction.Transactional;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -137,11 +137,11 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .build();
 
         // when
-        LocalDateTime testServerTime = LocalDateTime.of(2021, 10, 31, 0, 0, 0);
+        LocalDate testServerDate = LocalDate.of(2021, 10, 31);
         ScheduleCreateResponse response = scheduleService.createSchedule(u1.getUserSeq(),
             request);
         ScheduleDetailReadResponse schedule = scheduleService.getScheduleDetail(
-            response.scheduleSeq(), u1.getUserSeq(), testServerTime);
+            response.scheduleSeq(), u1.getUserSeq(), testServerDate);
 
         // then
         assertThat(schedule).isNotNull()
@@ -188,11 +188,11 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .build();
 
         // when
-        LocalDateTime testServerTime = LocalDateTime.of(2021, 10, 31, 0, 0, 0);
+        LocalDate testServerDate = LocalDate.of(2021, 10, 31);
         ScheduleCreateResponse response = scheduleService.createSchedule(u1.getUserSeq(),
             request);
         ScheduleDetailReadResponse schedule = scheduleService.getScheduleDetail(
-            response.scheduleSeq(), u1.getUserSeq(), testServerTime);
+            response.scheduleSeq(), u1.getUserSeq(), testServerDate);
 
         // then
         assertThat(schedule).isNotNull()
@@ -239,11 +239,11 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .build();
 
         // when
-        LocalDateTime testServerTime = LocalDateTime.of(2021, 10, 31, 0, 0, 0);
+        LocalDate testServerDate = LocalDate.of(2021, 10, 31);
         ScheduleCreateResponse response = scheduleService.createSchedule(u1.getUserSeq(),
             request);
         ScheduleDetailReadResponse schedule = scheduleService.getScheduleDetail(
-            response.scheduleSeq(), u1.getUserSeq(), testServerTime);
+            response.scheduleSeq(), u1.getUserSeq(), testServerDate);
 
         // then
         assertThat(schedule).isNotNull()
@@ -290,11 +290,11 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .build();
 
         // when
-        LocalDateTime testServerTime = LocalDateTime.of(2021, 10, 31, 0, 0, 0);
+        LocalDate testServerDate = LocalDate.of(2021, 10, 31);
         ScheduleCreateResponse response = scheduleService.createSchedule(u1.getUserSeq(),
             request);
         ScheduleDetailReadResponse schedule = scheduleService.getScheduleDetail(
-            response.scheduleSeq(), u1.getUserSeq(), testServerTime);
+            response.scheduleSeq(), u1.getUserSeq(), testServerDate);
 
         // then
         assertThat(schedule).isNotNull()
@@ -328,7 +328,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
         String expectedFormat = "yyyy-MM-dd";
 
         // when
-        String serverTime = scheduleService.getServerTime();
+        String serverTime = scheduleService.getServerDate();
 
         // then
         assertThat(serverTime).isNotNull();
@@ -377,17 +377,17 @@ class ScheduleServiceTest extends IntegrationTestSupport {
         scheduleService.createSchedule(u2.getUserSeq(), r2);
 
         // when
-        LocalDateTime testServerTime = LocalDateTime.of(2021, 10, 31, 0, 0, 0);
+        LocalDate testServerDate = LocalDate.of(2021, 10, 31);
         Map<String, String> searchCondition = Map.of("categories", "", "searchKey", "",
             "unscheduled", "", "month", "", "day", "", "year", "");
         List<ScheduleListReadResponse> user1Schedules = scheduleService.getScheduleListBySearchCondition(
-            u1.getUserSeq(), searchCondition, testServerTime);
+            u1.getUserSeq(), searchCondition, testServerDate);
         List<ScheduleListReadResponse> user2Schedules = scheduleService.getScheduleListBySearchCondition(
-            u2.getUserSeq(), searchCondition, testServerTime);
+            u2.getUserSeq(), searchCondition, testServerDate);
         Map<String, List<ScheduleListReadResponse>> user1Result = scheduleService.getScheduleListByCondition(
-            u1.getUserSeq(), searchCondition, testServerTime);
+            u1.getUserSeq(), searchCondition, testServerDate);
         Map<String, List<ScheduleListReadResponse>> user2Result = scheduleService.getScheduleListByCondition(
-            u2.getUserSeq(), searchCondition, testServerTime);
+            u2.getUserSeq(), searchCondition, testServerDate);
 
         // then
         assertThat(user1Schedules)
@@ -437,11 +437,11 @@ class ScheduleServiceTest extends IntegrationTestSupport {
         ScheduleCreateResponse createResponse = scheduleService.createSchedule(u1.getUserSeq(), r1);
 
         // when
-        LocalDateTime testServerTime = LocalDateTime.of(2021, 10, 31, 0, 0, 0);
+        LocalDate testServerDate = LocalDate.of(2021, 10, 31);
         ScheduleDetailReadResponse u1Response = scheduleService.getScheduleDetail(
-            createResponse.scheduleSeq(), u1.getUserSeq(), testServerTime);
+            createResponse.scheduleSeq(), u1.getUserSeq(), testServerDate);
         ScheduleDetailReadResponse u2Response = scheduleService.getScheduleDetail(
-            createResponse.scheduleSeq(), u2.getUserSeq(), testServerTime);
+            createResponse.scheduleSeq(), u2.getUserSeq(), testServerDate);
 
         // then
         assertThat(u1Response).isNotNull();
@@ -506,15 +506,15 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             String.valueOf(categories.get(0).getCategorySeq()), "searchKey", "", "unscheduled", "",
             "month", "", "day", "", "year", "");
 
-        LocalDateTime testServerTime = LocalDateTime.of(2021, 10, 31, 0, 0, 0);
+        LocalDate testServerDate = LocalDate.of(2021, 10, 31);
         List<ScheduleListReadResponse> result1 = scheduleService.getScheduleListBySearchCondition(
-            u1.getUserSeq(), searchCondition1, testServerTime);
+            u1.getUserSeq(), searchCondition1, testServerDate);
         List<ScheduleListReadResponse> result2 = scheduleService.getScheduleListBySearchCondition(
-            u1.getUserSeq(), searchCondition2, testServerTime);
+            u1.getUserSeq(), searchCondition2, testServerDate);
         Map<String, List<ScheduleListReadResponse>> mapResult1 = scheduleService.getScheduleListByCondition(
-            u1.getUserSeq(), searchCondition1, testServerTime);
+            u1.getUserSeq(), searchCondition1, testServerDate);
         Map<String, List<ScheduleListReadResponse>> mapResult2 = scheduleService.getScheduleListByCondition(
-            u1.getUserSeq(), searchCondition2, testServerTime);
+            u1.getUserSeq(), searchCondition2, testServerDate);
 
         // then
         assertThat(result1)
@@ -580,13 +580,13 @@ class ScheduleServiceTest extends IntegrationTestSupport {
         scheduleService.createSchedule(u1.getUserSeq(), r2);
 
         // when
-        LocalDateTime testServerTime = LocalDateTime.of(2021, 10, 31, 0, 0, 0);
+        LocalDate testServerDate = LocalDate.of(2021, 10, 31);
         Map<String, String> searchCondition = Map.of("searchKey", "일정", "unscheduled", "",
             "categories", "", "month", "", "day", "", "year", "");
         List<ScheduleListReadResponse> schedules = scheduleService.getScheduleListBySearchCondition(
-            u1.getUserSeq(), searchCondition, testServerTime);
+            u1.getUserSeq(), searchCondition, testServerDate);
         Map<String, List<ScheduleListReadResponse>> mapResult = scheduleService.getScheduleListByCondition(
-            u1.getUserSeq(), searchCondition, testServerTime);
+            u1.getUserSeq(), searchCondition, testServerDate);
 
         // then
         assertThat(schedules)
@@ -639,13 +639,13 @@ class ScheduleServiceTest extends IntegrationTestSupport {
         scheduleService.createSchedule(u1.getUserSeq(), r2);
 
         // when
-        LocalDateTime testServerTime = LocalDateTime.of(2021, 10, 31, 0, 0, 0);
+        LocalDate testServerDate = LocalDate.of(2021, 10, 31);
         Map<String, String> searchCondition = Map.of("categories", "", "searchKey", "",
             "unscheduled", "true", "month", "", "day", "", "year", "");
         List<ScheduleListReadResponse> result = scheduleService.getScheduleListBySearchCondition(
-            u1.getUserSeq(), searchCondition, testServerTime);
+            u1.getUserSeq(), searchCondition, testServerDate);
         Map<String, List<ScheduleListReadResponse>> mapResult = scheduleService.getScheduleListByCondition(
-            u1.getUserSeq(), searchCondition, testServerTime);
+            u1.getUserSeq(), searchCondition, testServerDate);
 
         // then
         assertThat(result)
@@ -746,17 +746,17 @@ class ScheduleServiceTest extends IntegrationTestSupport {
         scheduleService.createSchedule(u1.getUserSeq(), r6);
 
         // when
-        LocalDateTime testServerTime = LocalDateTime.of(2023, 11, 1, 9, 0, 0);
+        LocalDate testServerDate = LocalDate.of(2023, 11, 1);
         Map<String, String> searchCondition = Map.of("categories", "", "searchKey", "",
             "unscheduled", "", "month", "11", "day", "", "year", "2023");
         List<ScheduleListReadResponse> result1 = scheduleService.getScheduleListBySearchCondition(
-            u1.getUserSeq(), searchCondition, testServerTime);
+            u1.getUserSeq(), searchCondition, testServerDate);
         List<ScheduleListReadResponse> result2 = scheduleService.getScheduleListBySearchCondition(
-            u2.getUserSeq(), searchCondition, testServerTime);
+            u2.getUserSeq(), searchCondition, testServerDate);
         Map<String, List<ScheduleListReadResponse>> mapResult1 = scheduleService.getScheduleListByCondition(
-            u1.getUserSeq(), searchCondition, testServerTime);
+            u1.getUserSeq(), searchCondition, testServerDate);
         Map<String, List<ScheduleListReadResponse>> mapResult2 = scheduleService.getScheduleListByCondition(
-            u2.getUserSeq(), searchCondition, testServerTime);
+            u2.getUserSeq(), searchCondition, testServerDate);
 
         // then
         assertThat(result1)
@@ -873,17 +873,17 @@ class ScheduleServiceTest extends IntegrationTestSupport {
         scheduleService.createSchedule(u1.getUserSeq(), r6);
 
         // when
-        LocalDateTime testServerTime = LocalDateTime.of(2023, 11, 15, 0, 0, 0);
+        LocalDate testServerDate = LocalDate.of(2023, 11, 15);
         Map<String, String> searchCondition = Map.of("categories", "", "searchKey", "",
             "unscheduled", "", "month", "11", "day", "", "year", "2023");
         List<ScheduleListReadResponse> result1 = scheduleService.getScheduleListBySearchCondition(
-            u1.getUserSeq(), searchCondition, testServerTime);
+            u1.getUserSeq(), searchCondition, testServerDate);
         List<ScheduleListReadResponse> result2 = scheduleService.getScheduleListBySearchCondition(
-            u2.getUserSeq(), searchCondition, testServerTime);
+            u2.getUserSeq(), searchCondition, testServerDate);
         Map<String, List<ScheduleListReadResponse>> mapResult1 = scheduleService.getScheduleListByCondition(
-            u1.getUserSeq(), searchCondition, testServerTime);
+            u1.getUserSeq(), searchCondition, testServerDate);
         Map<String, List<ScheduleListReadResponse>> mapResult2 = scheduleService.getScheduleListByCondition(
-            u2.getUserSeq(), searchCondition, testServerTime);
+            u2.getUserSeq(), searchCondition, testServerDate);
 
         // then
         assertThat(result1)
@@ -990,17 +990,17 @@ class ScheduleServiceTest extends IntegrationTestSupport {
         scheduleService.createSchedule(u2.getUserSeq(), r5);
 
         // when
-        LocalDateTime testServerTime = LocalDateTime.of(2023, 11, 1, 9, 0, 0);
+        LocalDate testServerDate = LocalDate.of(2023, 11, 1);
         Map<String, String> searchCondition = Map.of("categories", "", "searchKey", "",
             "unscheduled", "", "month", "11", "day", "1", "year", "2023");
         List<ScheduleListReadResponse> result1 = scheduleService.getScheduleListBySearchCondition(
-            u1.getUserSeq(), searchCondition, testServerTime);
+            u1.getUserSeq(), searchCondition, testServerDate);
         List<ScheduleListReadResponse> result2 = scheduleService.getScheduleListBySearchCondition(
-            u2.getUserSeq(), searchCondition, testServerTime);
+            u2.getUserSeq(), searchCondition, testServerDate);
         Map<String, List<ScheduleListReadResponse>> mapResult1 = scheduleService.getScheduleListByCondition(
-            u1.getUserSeq(), searchCondition, testServerTime);
+            u1.getUserSeq(), searchCondition, testServerDate);
         Map<String, List<ScheduleListReadResponse>> mapResult2 = scheduleService.getScheduleListByCondition(
-            u2.getUserSeq(), searchCondition, testServerTime);
+            u2.getUserSeq(), searchCondition, testServerDate);
 
         // then
         assertThat(result1)
@@ -1097,16 +1097,16 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .build();
 
         // when
-        LocalDateTime testServerTime = LocalDateTime.of(2021, 10, 31, 0, 0, 0);
+        LocalDate testServerDate = LocalDate.of(2021, 10, 31);
         scheduleService.updateSchedule(
             u1.getUserSeq(), schedule.scheduleSeq(), scheduleUpdateRequest);
 
         ScheduleDetailReadResponse response1 = scheduleService.getScheduleDetail(
             schedule.scheduleSeq(),
-            u1.getUserSeq(), testServerTime);
+            u1.getUserSeq(), testServerDate);
         ScheduleDetailReadResponse response2 = scheduleService.getScheduleDetail(
             schedule.scheduleSeq(),
-            u2.getUserSeq(), testServerTime);
+            u2.getUserSeq(), testServerDate);
 
         // then
         assertThat(response1.scheduleSeq()).isEqualTo(response2.scheduleSeq());
@@ -1158,15 +1158,15 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .build();
 
         // when
-        LocalDateTime testServerTime = LocalDateTime.of(2021, 10, 31, 0, 0, 0);
+        LocalDate testServerDate = LocalDate.of(2021, 10, 31);
         ScheduleUpdateResponse updateResponse = scheduleService.updateSchedule(
             u2.getUserSeq(), createResponse.scheduleSeq(), scheduleUpdateRequest);
         ScheduleDetailReadResponse response1 = scheduleService.getScheduleDetail(
             updateResponse.scheduleSeq(),
-            u1.getUserSeq(), testServerTime);
+            u1.getUserSeq(), testServerDate);
         ScheduleDetailReadResponse response2 = scheduleService.getScheduleDetail(
             updateResponse.scheduleSeq(),
-            u3.getUserSeq(), testServerTime);
+            u3.getUserSeq(), testServerDate);
 
         // then
         assertThat(response2).isNotNull();
@@ -1299,13 +1299,13 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             schedule.scheduleSeq(),
             updateRequest);
 
-        LocalDateTime testServerTime = LocalDateTime.of(2021, 10, 31, 0, 0, 0);
+        LocalDate testServerDate = LocalDate.of(2021, 10, 31);
         Optional<Participation> result1 = participationRepository.findBySchedule_ScheduleSeqAndUser_UserSeqAndIsDeletedFalse(
             updateResponse.scheduleSeq(), u1.getUserSeq());
         List<ScheduleListReadResponse> result2 = scheduleService.getScheduleListBySearchCondition(
             u1.getUserSeq(), Map.of("categories", String.valueOf(category.getCategorySeq()),
                 "searchKey", "", "unscheduled", "", "month", "", "day", "", "year", ""),
-            testServerTime);
+            testServerDate);
 
         // then
         assertThat(result1).isPresent();
@@ -1365,14 +1365,14 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             s1.scheduleSeq(),
             updateRequest);
 
-        LocalDateTime testServerTime = LocalDateTime.of(2021, 10, 31, 0, 0, 0);
+        LocalDate testServerDate = LocalDate.of(2021, 10, 31);
         List<ScheduleListReadResponse> result = scheduleService.getScheduleListBySearchCondition(
             u1.getUserSeq(), Map.of("categories", String.valueOf(category.getCategorySeq()),
                 "searchKey", "", "unscheduled", "", "month", "", "day", "", "year", ""),
-            testServerTime);
+            testServerDate);
         ScheduleDetailReadResponse result2 = scheduleService.getScheduleDetail(
             updateResponse.scheduleSeq(),
-            u1.getUserSeq(), testServerTime);
+            u1.getUserSeq(), testServerDate);
 
         // then
         assertThat(result).hasSize(1)
@@ -1488,9 +1488,9 @@ class ScheduleServiceTest extends IntegrationTestSupport {
         scheduleService.createCommentOnSchedule(
             schedule.scheduleSeq(), user.getUserSeq(), CommentCreateRequest.of("세상에서 제일 불행한 사람임"));
 
-        LocalDateTime testServerTime = LocalDateTime.of(2021, 10, 31, 0, 0, 0);
+        LocalDate testServerDate = LocalDate.of(2021, 10, 31);
         CommentReadResponse response = scheduleService.getScheduleDetail(schedule.scheduleSeq(),
-            user.getUserSeq(), testServerTime).comments().get(0);
+            user.getUserSeq(), testServerDate).comments().get(0);
 
         // then
         assertThat(response).isNotNull()
@@ -1519,15 +1519,15 @@ class ScheduleServiceTest extends IntegrationTestSupport {
         ScheduleCreateResponse schedule = scheduleService.createSchedule(user.getUserSeq(),
             request);
 
-        LocalDateTime testServerTime = LocalDateTime.of(2021, 10, 31, 0, 0, 0);
+        LocalDate testServerDate = LocalDate.of(2021, 10, 31);
         scheduleService.createCommentOnSchedule(
             schedule.scheduleSeq(), user.getUserSeq(), CommentCreateRequest.of("세상에서 제일 불행한 사람임"));
         CommentReadResponse r1 = scheduleService.getScheduleDetail(schedule.scheduleSeq(),
-            user.getUserSeq(), testServerTime).comments().get(0);
+            user.getUserSeq(), testServerDate).comments().get(0);
         scheduleService.createCommentOnSchedule(schedule.scheduleSeq(),
             user.getUserSeq(), CommentCreateRequest.of("얘는 삭제될거임"));
         CommentReadResponse r2 = scheduleService.getScheduleDetail(schedule.scheduleSeq(),
-            user.getUserSeq(), testServerTime).comments().get(1);
+            user.getUserSeq(), testServerDate).comments().get(1);
 
         // when
         scheduleService.deleteComment(r2.commentSeq(), user.getUserSeq());
@@ -1714,9 +1714,9 @@ class ScheduleServiceTest extends IntegrationTestSupport {
         Long scheduleSeq = 3L;
         User user = userRepository.findAll().get(0);
 
-        LocalDateTime testServerTime = LocalDateTime.of(2021, 10, 31, 0, 0, 0);
+        LocalDate testServerDate = LocalDate.of(2021, 10, 31);
         assertThatThrownBy(
-            () -> scheduleService.getScheduleDetail(scheduleSeq, user.getUserSeq(), testServerTime))
+            () -> scheduleService.getScheduleDetail(scheduleSeq, user.getUserSeq(), testServerDate))
             .isInstanceOf(RestApiException.class)
             .hasMessage("SCHEDULE_NOT_FOUND");
     }
@@ -2024,9 +2024,9 @@ class ScheduleServiceTest extends IntegrationTestSupport {
         scheduleService.createCommentOnSchedule(
             s.getScheduleSeq(), user.getUserSeq(), CommentCreateRequest.of("세상에서 제일 불행한 사람임"));
 
-        LocalDateTime testServerTime = LocalDateTime.of(2021, 10, 31, 0, 0, 0);
+        LocalDate testServerDate = LocalDate.of(2021, 10, 31);
         CommentReadResponse response = scheduleService.getScheduleDetail(s.getScheduleSeq(),
-            user.getUserSeq(), testServerTime).comments().get(0);
+            user.getUserSeq(), testServerDate).comments().get(0);
 
         // when // then
         assertThatThrownBy(
@@ -2060,9 +2060,9 @@ class ScheduleServiceTest extends IntegrationTestSupport {
         scheduleService.createCommentOnSchedule(
             s.getScheduleSeq(), u1.getUserSeq(), CommentCreateRequest.of("세상에서 제일 불행한 사람임"));
 
-        LocalDateTime testServerTime = LocalDateTime.of(2021, 10, 31, 0, 0, 0);
+        LocalDate testServerDate = LocalDate.of(2021, 10, 31);
         CommentReadResponse response = scheduleService.getScheduleDetail(s.getScheduleSeq(),
-            u1.getUserSeq(), testServerTime).comments().get(0);
+            u1.getUserSeq(), testServerDate).comments().get(0);
 
         // when // then
         assertThatThrownBy(
@@ -2159,11 +2159,11 @@ class ScheduleServiceTest extends IntegrationTestSupport {
         // when
         Map<String, String> searchCondition = Map.of("categories", "", "searchKey", "",
             "unscheduled", "", "month", "11", "day", "1", "year", "");
-        LocalDateTime testServerTime = LocalDateTime.of(2021, 10, 31, 0, 0, 0);
+        LocalDate testServerDate = LocalDate.of(2021, 10, 31);
 
         // then
         assertThatThrownBy(() -> scheduleService.getScheduleListBySearchCondition(
-            u1.getUserSeq(), searchCondition, testServerTime))
+            u1.getUserSeq(), searchCondition, testServerDate))
             .isInstanceOf(RestApiException.class)
             .hasMessage("SCHEDULE_INVALID_REQUEST");
     }
@@ -2241,11 +2241,11 @@ class ScheduleServiceTest extends IntegrationTestSupport {
         // when
         Map<String, String> searchCondition = Map.of("categories", "", "searchKey", "",
             "unscheduled", "", "month", "", "day", "1", "year", "2023");
-        LocalDateTime testServerTime = LocalDateTime.of(2021, 10, 31, 0, 0, 0);
+        LocalDate testServerDate = LocalDate.of(2021, 10, 31);
 
         // then
         assertThatThrownBy(() -> scheduleService.getScheduleListBySearchCondition(
-            u1.getUserSeq(), searchCondition, testServerTime))
+            u1.getUserSeq(), searchCondition, testServerDate))
             .isInstanceOf(RestApiException.class)
             .hasMessage("SCHEDULE_INVALID_REQUEST");
     }


### PR DESCRIPTION
## 개요
- 일정 조회 시 response에 API 호출 시 시간을 기준으로 일정의 종료 여부를 판단하는 `isFinished` 필드를 추가했습니다.
- 이제 API를 통해 서버 시간 전달 요청시 시간 정보를 전달하지 않습니다. 

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).