### PR TITLE
Chore: friends 페이지 expose 및 기타 설정

### DIFF
--- a/frontend/_apps/shell/pages/friends/index.tsx
+++ b/frontend/_apps/shell/pages/friends/index.tsx
@@ -1,0 +1,14 @@
+import dynamic from 'next/dynamic';
+import { Suspense } from 'react';
+
+const Friend = dynamic(() => import('user/Friend'), { ssr: false });
+
+export default function Page() {
+  return (
+    <>
+      <Suspense fallback={<>loading</>}>
+        <Friend />
+      </Suspense>
+    </>
+  );
+}

--- a/frontend/_apps/user/next.config.js
+++ b/frontend/_apps/user/next.config.js
@@ -32,7 +32,9 @@ module.exports = withVanillaExtract({
         new NextFederationPlugin({
           name: 'user',
           filename: 'static/chunks/entry.js',
-          exposes: {},
+          exposes: {
+            './Friend': './pages/friend/index',
+          },
           shared: {},
         })
       );

--- a/frontend/_packages/global-types/mf/mf-types.d.ts
+++ b/frontend/_packages/global-types/mf/mf-types.d.ts
@@ -1,0 +1,4 @@
+declare module 'user/Friend' {
+  const Friend: React.LazyExoticComponent<React.FC>;
+  export default Friend;
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,15 +1,16 @@
 {
   "private": true,
   "scripts": {
-    "build": "turbo run build",
-    "dev": "turbo run dev",
-    "lint": "turbo run lint",
+    "build": "turbo run build --concurrency 15",
+    "dev": "dotenv -- turbo run dev --concurrency 15",
+    "lint": "turbo run lint --concurrency 15",
     "format": "prettier --write \"**/*.{ts,tsx,md}\""
   },
   "devDependencies": {
     "eslint": "^8.48.0",
     "prettier": "^3.0.3",
     "tsconfig": "workspace:*",
+    "dotenv-cli": "latest",
     "turbo": "latest"
   },
   "packageManager": "pnpm@8.6.10",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      dotenv-cli:
+        specifier: latest
+        version: 7.3.0
       eslint:
         specifier: ^8.48.0
         version: 8.48.0
@@ -8527,6 +8530,16 @@ packages:
     dependencies:
       no-case: 3.0.4
       tslib: 2.5.0
+    dev: true
+
+  /dotenv-cli@7.3.0:
+    resolution: {integrity: sha512-314CA4TyK34YEJ6ntBf80eUY+t1XaFLyem1k9P0sX1gn30qThZ5qZr/ZwE318gEnzyYP9yj9HJk6SqwE0upkfw==}
+    hasBin: true
+    dependencies:
+      cross-spawn: 7.0.3
+      dotenv: 16.3.1
+      dotenv-expand: 10.0.0
+      minimist: 1.2.8
     dev: true
 
   /dotenv-expand@10.0.0:

--- a/frontend/turbo.json
+++ b/frontend/turbo.json
@@ -1,21 +1,18 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "globalDependencies": ["**/.env.*local"],
+  "globalDependencies": [".env"],
   "globalDotEnv": [".env"],
   "pipeline": {
     "build": {
-      "dotEnv": [".env.production.local", ".env.local", ".env.production", ".env"],
       "dependsOn": ["^build"],
       "outputs": [".next/**", "!.next/cache/**"]
     },
     "lint": {},
     "dev": {
-      "dotEnv": [".env.development.local", ".env.local", ".env.development", ".env"],
       "cache": false,
       "persistent": true
     },
     "test": {
-      "dotEnv": [".env.test.local", ".env.test", ".env"]
     }
   }
 }


### PR DESCRIPTION
## 개요

- user에 있던 module federation 페이지를 expose해서, shell의 friend/index.tsx에서 불러옵니다.
- expose할 때는 typescript 대응을 위해 global-types/mf에서 declare module 해주셔야 합니다.
- 모듈 개수가 늘어남에 따라 동시에 빌드 및 dev server를 실행할 수 있는 최대 갯수를 상향 조정합니다 (기본 10 -> 15)
- global .env가 로컬 환경에서 제대로 동작하지 않는 문제가 있었습니다. 이 부분을 수정합니다. (dotenv-cli 설치)

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).