### PR TITLE
Fix: 일정 상세보기 시 authorizedUser 반환하도록 수정

### DIFF
--- a/backend/src/main/java/com/pppppp/amadda/schedule/dto/response/ScheduleDetailReadResponse.java
+++ b/backend/src/main/java/com/pppppp/amadda/schedule/dto/response/ScheduleDetailReadResponse.java
@@ -18,6 +18,7 @@ public record ScheduleDetailReadResponse(
     Boolean isAuthorizedAll,
     String scheduleStartAt,
     String scheduleEndAt,
+    UserReadResponse authorizedUser,
     List<UserReadResponse> participants,
     Boolean isFinished,
 
@@ -48,6 +49,9 @@ public record ScheduleDetailReadResponse(
                 (schedule.isDateSelected()) ? schedule.getScheduleStartAt().format(formatter) : "")
             .scheduleEndAt(
                 (schedule.isTimeSelected()) ? schedule.getScheduleEndAt().format(formatter) : "")
+            .authorizedUser(
+                !(schedule.isAuthorizedAll()) ? UserReadResponse.of(schedule.getAuthorizedUser())
+                    : null)
             .participants(participants)
             .isFinished(isFinished)
             .alarmTime(participation.getAlarmTime().getContent())

--- a/backend/src/test/java/com/pppppp/amadda/schedule/service/ScheduleServiceTest.java
+++ b/backend/src/test/java/com/pppppp/amadda/schedule/service/ScheduleServiceTest.java
@@ -1122,10 +1122,10 @@ class ScheduleServiceTest extends IntegrationTestSupport {
         assertThat(response1)
             .extracting("scheduleName", "scheduleMemo", "scheduleContent",
                 "isDateSelected", "isTimeSelected", "isAllDay", "scheduleStartAt", "scheduleEndAt",
-                "alarmTime", "isAuthorizedAll")
+                "alarmTime", "isAuthorizedAll", "authorizedUser")
             .containsExactly(
                 "안녕 내가 일정 이름이야", "이거는 안되는 메모고", "여기는 동기화 되는 메모야", false, false, false,
-                "", "", "알림 없음", false);
+                "", "", "알림 없음", false, UserReadResponse.of(u1));
         assertThat(response2)
             .extracting("scheduleName")
             .isEqualTo("안녕 내가 일정 이름이야");
@@ -1251,10 +1251,10 @@ class ScheduleServiceTest extends IntegrationTestSupport {
         assertThat(response1)
             .extracting("scheduleName", "scheduleMemo", "scheduleContent",
                 "isDateSelected", "isTimeSelected", "isAllDay", "scheduleStartAt", "scheduleEndAt",
-                "alarmTime", "isAuthorizedAll")
+                "alarmTime", "isAuthorizedAll", "authorizedUser")
             .containsExactly(
                 "안녕 내가 일정 이름이야", "이거는 안되는 메모고", "여기는 동기화 되는 메모야", false, false, false,
-                "", "", "알림 없음", true);
+                "", "", "알림 없음", true, null);
         assertThat(response2)
             .extracting("scheduleName", "alarmTime")
             .containsExactly("안녕 내가 일정 이름이야", "알림 없음");


### PR DESCRIPTION
## 개요
- 일정 상세 정보를 반환할 때 일정 생성자 정보를 반환하지 않는 오류를 수정했습니다.

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).