### PR TITLE
Fix: 참가정보 생성, 수정 request 시 알림 시간 설정 방법 수정

### DIFF
--- a/backend/src/main/java/com/pppppp/amadda/schedule/dto/request/ParticipationUpdateRequest.java
+++ b/backend/src/main/java/com/pppppp/amadda/schedule/dto/request/ParticipationUpdateRequest.java
@@ -1,13 +1,12 @@
 package com.pppppp.amadda.schedule.dto.request;
 
-import com.pppppp.amadda.schedule.entity.AlarmTime;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 
 @Builder
 public record ParticipationUpdateRequest(
-    @NotNull(message = "알림 시간 설정이 필요해요!") AlarmTime alarmTime,
+    @NotNull(message = "알림 시간 설정이 필요해요!") String alarmTime,
     @NotBlank(message = "일정 이름을 입력해 주세요!") String scheduleName,
     @NotNull(message = "유효하지 않은 요청입니다.") String scheduleMemo,
     Long categorySeq

--- a/backend/src/main/java/com/pppppp/amadda/schedule/dto/request/ScheduleCreateRequest.java
+++ b/backend/src/main/java/com/pppppp/amadda/schedule/dto/request/ScheduleCreateRequest.java
@@ -1,6 +1,5 @@
 package com.pppppp.amadda.schedule.dto.request;
 
-import com.pppppp.amadda.schedule.entity.AlarmTime;
 import com.pppppp.amadda.schedule.entity.Participation;
 import com.pppppp.amadda.schedule.entity.Schedule;
 import com.pppppp.amadda.user.dto.response.UserReadResponse;
@@ -26,7 +25,7 @@ public record ScheduleCreateRequest(
 
     // ================ Participation =================
 
-    @NotNull(message = "알림 시간 설정이 필요해요!") AlarmTime alarmTime,
+    @NotNull(message = "알림 시간 설정이 필요해요!") String alarmTime,
     @NotBlank(message = "일정 이름을 입력해 주세요!") String scheduleName,
     @NotNull(message = "유효하지 않은 요청입니다.") String scheduleMemo,
 
@@ -45,7 +44,7 @@ public record ScheduleCreateRequest(
             .scheduleStartAt(String.valueOf(schedule.getScheduleStartAt()))
             .scheduleEndAt(String.valueOf(schedule.getScheduleEndAt()))
             .participants(participants)
-            .alarmTime(participation.getAlarmTime())
+            .alarmTime(String.valueOf(participation.getAlarmTime()))
             .scheduleName(participation.getScheduleName())
             .scheduleMemo(participation.getScheduleMemo())
             .categorySeq(participation.getCategory().getCategorySeq())

--- a/backend/src/main/java/com/pppppp/amadda/schedule/entity/Participation.java
+++ b/backend/src/main/java/com/pppppp/amadda/schedule/entity/Participation.java
@@ -89,14 +89,16 @@ public class Participation extends BaseEntity {
 
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 
+        AlarmTime alarmTime = AlarmTime.valueOf(request.alarmTime());
+
         LocalDateTime alarmAt =
             (request.isTimeSelected()) ? LocalDateTime.parse(request.scheduleStartAt(), formatter)
-                .minusMinutes(request.alarmTime().getMinute()) : null;
+                .minusMinutes(alarmTime.getMinute()) : null;
 
         return Participation.builder()
             .scheduleName(request.scheduleName())
             .scheduleMemo(request.scheduleMemo())
-            .alarmTime(request.alarmTime())
+            .alarmTime(alarmTime)
             .alarmAt(alarmAt)
             .user(participant)
             .schedule(schedule)
@@ -110,7 +112,7 @@ public class Participation extends BaseEntity {
     public void updateParticipationInfo(ParticipationUpdateRequest request) {
         this.scheduleName = request.scheduleName();
         this.scheduleMemo = request.scheduleMemo();
-        this.alarmTime = request.alarmTime();
+        this.alarmTime = AlarmTime.valueOf(request.alarmTime());
     }
 
     public void updateAlarmAt(LocalDateTime startAt) {

--- a/backend/src/main/java/com/pppppp/amadda/schedule/service/ScheduleService.java
+++ b/backend/src/main/java/com/pppppp/amadda/schedule/service/ScheduleService.java
@@ -638,7 +638,7 @@ public class ScheduleService {
             .scheduleEndAt(request.scheduleEndAt())
             .participants(request.participants())
             .scheduleName(scheduleName)
-            .alarmTime(alarmTime)
+            .alarmTime(String.valueOf(alarmTime))
             .build();
 
         updateParticipationList

--- a/backend/src/test/java/com/pppppp/amadda/alarm/service/AlarmServiceTest.java
+++ b/backend/src/test/java/com/pppppp/amadda/alarm/service/AlarmServiceTest.java
@@ -31,7 +31,6 @@ import com.pppppp.amadda.friend.repository.FriendRequestRepository;
 import com.pppppp.amadda.global.entity.exception.RestApiException;
 import com.pppppp.amadda.global.entity.exception.errorcode.AlarmErrorCode;
 import com.pppppp.amadda.schedule.dto.request.ScheduleCreateRequest;
-import com.pppppp.amadda.schedule.entity.AlarmTime;
 import com.pppppp.amadda.schedule.entity.Participation;
 import com.pppppp.amadda.schedule.entity.Schedule;
 import com.pppppp.amadda.schedule.repository.ParticipationRepository;
@@ -1084,7 +1083,7 @@ class AlarmServiceTest extends IntegrationTestSupport {
             .scheduleEndAt(endTime)
             .participants(List.of(UserReadResponse.of(user)))
             // participation
-            .alarmTime(AlarmTime.ON_TIME)
+            .alarmTime("ON_TIME")
             .scheduleName("합창단 공연")
             .scheduleMemo("수원역에서 걸어서 10분")
             .build();

--- a/backend/src/test/java/com/pppppp/amadda/schedule/controller/ScheduleControllerTest.java
+++ b/backend/src/test/java/com/pppppp/amadda/schedule/controller/ScheduleControllerTest.java
@@ -23,7 +23,6 @@ import com.pppppp.amadda.schedule.dto.response.CategoryUpdateResponse;
 import com.pppppp.amadda.schedule.dto.response.ParticipationUpdateResponse;
 import com.pppppp.amadda.schedule.dto.response.ScheduleCreateResponse;
 import com.pppppp.amadda.schedule.dto.response.ScheduleUpdateResponse;
-import com.pppppp.amadda.schedule.entity.AlarmTime;
 import com.pppppp.amadda.user.dto.response.UserReadResponse;
 import com.pppppp.amadda.user.entity.User;
 import java.time.LocalDate;
@@ -55,7 +54,7 @@ class ScheduleControllerTest extends ControllerTestSupport {
             // participation
             .scheduleName("합창단 공연")
             .scheduleMemo("수원역에서 걸어서 10분")
-            .alarmTime(AlarmTime.ONE_DAY_BEFORE)
+            .alarmTime("ONE_DAY_BEFORE")
             .build();
 
         // stubbing
@@ -290,7 +289,7 @@ class ScheduleControllerTest extends ControllerTestSupport {
         ParticipationUpdateRequest request = ParticipationUpdateRequest.builder()
             .scheduleName("합창단 공연")
             .scheduleMemo("수원역에서 걸어서 10분")
-            .alarmTime(AlarmTime.valueOf(alarmTime))
+            .alarmTime(alarmTime)
             .build();
 
         // stubbing
@@ -436,7 +435,7 @@ class ScheduleControllerTest extends ControllerTestSupport {
             .participants(List.of(UserReadResponse.of(user)))
             // participation
             .scheduleMemo("수원역에서 걸어서 10분")
-            .alarmTime(AlarmTime.ONE_DAY_BEFORE)
+            .alarmTime("ONE_DAY_BEFORE")
             .build();
 
         mockMvc.perform(
@@ -467,7 +466,7 @@ class ScheduleControllerTest extends ControllerTestSupport {
             // participation
             .scheduleName("합창단 공연")
             .scheduleMemo("수원역에서 걸어서 10분")
-            .alarmTime(AlarmTime.ONE_DAY_BEFORE)
+            .alarmTime("ONE_DAY_BEFORE")
             .build();
 
         // when  // then
@@ -498,7 +497,7 @@ class ScheduleControllerTest extends ControllerTestSupport {
             // participation
             .scheduleName("합창단 공연")
             .scheduleMemo("수원역에서 걸어서 10분")
-            .alarmTime(AlarmTime.ONE_DAY_BEFORE)
+            .alarmTime("ONE_DAY_BEFORE")
             .build();
 
         // when  // then
@@ -529,7 +528,7 @@ class ScheduleControllerTest extends ControllerTestSupport {
             // participation
             .scheduleName("합창단 공연")
             .scheduleMemo("수원역에서 걸어서 10분")
-            .alarmTime(AlarmTime.ONE_DAY_BEFORE)
+            .alarmTime("ONE_DAY_BEFORE")
             .build();
 
         // when  // then
@@ -560,7 +559,7 @@ class ScheduleControllerTest extends ControllerTestSupport {
             // participation
             .scheduleName("합창단 공연")
             .scheduleMemo("수원역에서 걸어서 10분")
-            .alarmTime(AlarmTime.ONE_DAY_BEFORE)
+            .alarmTime("ONE_DAY_BEFORE")
             .build();
 
         // when  // then
@@ -701,7 +700,7 @@ class ScheduleControllerTest extends ControllerTestSupport {
     void noScheduleNameToUpdate() throws Exception {
         ParticipationUpdateRequest request = ParticipationUpdateRequest.builder()
             .scheduleMemo("수원역에서 걸어서 10분")
-            .alarmTime(AlarmTime.NONE)
+            .alarmTime("NONE")
             .build();
 
         // stubbing

--- a/backend/src/test/java/com/pppppp/amadda/schedule/service/ScheduleServiceTest.java
+++ b/backend/src/test/java/com/pppppp/amadda/schedule/service/ScheduleServiceTest.java
@@ -139,7 +139,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .isDateSelected(false)
             .isTimeSelected(false)
             .isAllDay(false)
-            .alarmTime(AlarmTime.NONE)
+            .alarmTime("NONE")
             .isAuthorizedAll(false)
             .participants(List.of(
                 UserReadResponse.of(u1), UserReadResponse.of(u2)))
@@ -190,7 +190,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .isAllDay(false)
             .scheduleStartAt("2023-11-02 00:00:00")
             .scheduleEndAt("")
-            .alarmTime(AlarmTime.NONE)
+            .alarmTime("NONE")
             .isAuthorizedAll(false)
             .participants(List.of(
                 UserReadResponse.of(u1), UserReadResponse.of(u2)))
@@ -241,7 +241,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .isAllDay(false)
             .scheduleStartAt("2023-11-01 09:00:00")
             .scheduleEndAt("2023-11-01 18:00:00")
-            .alarmTime(AlarmTime.NONE)
+            .alarmTime("NONE")
             .isAuthorizedAll(false)
             .participants(List.of(
                 UserReadResponse.of(u1), UserReadResponse.of(u2)))
@@ -292,7 +292,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .isAllDay(true)
             .scheduleStartAt("2023-11-01 00:00:00")
             .scheduleEndAt("2023-11-01 23:59:59")
-            .alarmTime(AlarmTime.NONE)
+            .alarmTime("NONE")
             .isAuthorizedAll(false)
             .participants(List.of(
                 UserReadResponse.of(u1), UserReadResponse.of(u2)))
@@ -367,7 +367,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .isDateSelected(false)
             .isAllDay(false)
             .isAuthorizedAll(false)
-            .alarmTime(AlarmTime.NONE)
+            .alarmTime("NONE")
             .participants(List.of(
                 UserReadResponse.of(u1), UserReadResponse.of(u2)))
             .build();
@@ -379,7 +379,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .scheduleStartAt("2023-11-01 08:59:30")
             .scheduleEndAt("2023-11-02 09:00:00")
             .isAuthorizedAll(false)
-            .alarmTime(AlarmTime.ON_TIME)
+            .alarmTime("ON_TIME")
             .participants(List.of(UserReadResponse.of(u2)))
             .build();
         scheduleService.createSchedule(u1.getUserSeq(), r1);
@@ -439,7 +439,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .isDateSelected(false)
             .isAllDay(false)
             .isAuthorizedAll(false)
-            .alarmTime(AlarmTime.NONE)
+            .alarmTime("NONE")
             .participants(List.of(
                 UserReadResponse.of(u1), UserReadResponse.of(u2)))
             .build();
@@ -484,7 +484,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .isDateSelected(false)
             .isTimeSelected(false)
             .isAllDay(false)
-            .alarmTime(AlarmTime.NONE)
+            .alarmTime("NONE")
             .isAuthorizedAll(false)
             .participants(List.of(
                 UserReadResponse.of(u1)))
@@ -497,7 +497,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .isDateSelected(false)
             .isTimeSelected(false)
             .isAllDay(false)
-            .alarmTime(AlarmTime.NONE)
+            .alarmTime("NONE")
             .isAuthorizedAll(false)
             .participants(List.of(
                 UserReadResponse.of(u1)))
@@ -570,7 +570,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .isDateSelected(false)
             .isAllDay(false)
             .isAuthorizedAll(false)
-            .alarmTime(AlarmTime.NONE)
+            .alarmTime("NONE")
             .participants(List.of(
                 UserReadResponse.of(u1)))
             .build();
@@ -582,7 +582,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .scheduleStartAt("2023-11-01 08:59:30")
             .scheduleEndAt("2023-11-01 09:00:00")
             .isAuthorizedAll(false)
-            .alarmTime(AlarmTime.ON_TIME)
+            .alarmTime("ON_TIME")
             .participants(List.of(UserReadResponse.of(u1)))
             .build();
         scheduleService.createSchedule(u1.getUserSeq(), r1);
@@ -629,7 +629,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .isDateSelected(false)
             .isAllDay(false)
             .isAuthorizedAll(false)
-            .alarmTime(AlarmTime.NONE)
+            .alarmTime("NONE")
             .participants(List.of(
                 UserReadResponse.of(u1)))
             .build();
@@ -641,7 +641,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .scheduleStartAt("2023-11-01 08:59:30")
             .scheduleEndAt("2023-11-01 09:00:00")
             .isAuthorizedAll(false)
-            .alarmTime(AlarmTime.ON_TIME)
+            .alarmTime("ON_TIME")
             .participants(List.of(UserReadResponse.of(u1)))
             .build();
         scheduleService.createSchedule(u1.getUserSeq(), r1);
@@ -688,7 +688,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .scheduleStartAt("2023-10-01 08:59:30")
             .scheduleEndAt("2023-11-01 09:00:00")
             .isAuthorizedAll(false)
-            .alarmTime(AlarmTime.NONE)
+            .alarmTime("NONE")
             .participants(List.of(
                 UserReadResponse.of(u1)))
             .build();
@@ -700,7 +700,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .scheduleStartAt("2023-11-01 08:59:30")
             .scheduleEndAt("2023-11-01 09:00:00")
             .isAuthorizedAll(false)
-            .alarmTime(AlarmTime.ON_TIME)
+            .alarmTime("ON_TIME")
             .participants(List.of(UserReadResponse.of(u1), UserReadResponse.of(u2)))
             .build();
         ScheduleCreateRequest r3 = ScheduleCreateRequest.builder()
@@ -711,7 +711,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .scheduleStartAt("2023-10-30 08:59:30")
             .scheduleEndAt("2023-10-30 09:00:00")
             .isAuthorizedAll(false)
-            .alarmTime(AlarmTime.ON_TIME)
+            .alarmTime("ON_TIME")
             .participants(List.of(UserReadResponse.of(u1), UserReadResponse.of(u2)))
             .build();
         ScheduleCreateRequest r4 = ScheduleCreateRequest.builder()
@@ -722,7 +722,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .scheduleStartAt("2023-11-30 08:59:30")
             .scheduleEndAt("2023-12-01 09:00:00")
             .isAuthorizedAll(false)
-            .alarmTime(AlarmTime.ON_TIME)
+            .alarmTime("ON_TIME")
             .participants(List.of(UserReadResponse.of(u1)))
             .build();
         ScheduleCreateRequest r5 = ScheduleCreateRequest.builder()
@@ -733,7 +733,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .scheduleStartAt("2022-11-30 08:59:30")
             .scheduleEndAt("2022-12-01 09:00:00")
             .isAuthorizedAll(false)
-            .alarmTime(AlarmTime.ON_TIME)
+            .alarmTime("ON_TIME")
             .participants(List.of(UserReadResponse.of(u2)))
             .build();
         ScheduleCreateRequest r6 = ScheduleCreateRequest.builder()
@@ -744,7 +744,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .scheduleStartAt("2023-10-30 08:59:30")
             .scheduleEndAt("2023-12-01 09:00:00")
             .isAuthorizedAll(false)
-            .alarmTime(AlarmTime.ON_TIME)
+            .alarmTime("ON_TIME")
             .participants(List.of(UserReadResponse.of(u1)))
             .build();
         scheduleService.createSchedule(u1.getUserSeq(), r1);
@@ -816,7 +816,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .scheduleStartAt("2023-10-01 08:59:30")
             .scheduleEndAt("2023-11-01 09:00:00")
             .isAuthorizedAll(false)
-            .alarmTime(AlarmTime.NONE)
+            .alarmTime("NONE")
             .participants(List.of(
                 UserReadResponse.of(u1)))
             .build();
@@ -828,7 +828,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .scheduleStartAt("2023-11-01 08:59:30")
             .scheduleEndAt("2023-11-01 09:00:00")
             .isAuthorizedAll(false)
-            .alarmTime(AlarmTime.ON_TIME)
+            .alarmTime("ON_TIME")
             .participants(List.of(UserReadResponse.of(u1), UserReadResponse.of(u2)))
             .build();
         ScheduleCreateRequest r3 = ScheduleCreateRequest.builder()
@@ -839,7 +839,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .scheduleStartAt("2023-10-30 08:59:30")
             .scheduleEndAt("2023-10-30 09:00:00")
             .isAuthorizedAll(false)
-            .alarmTime(AlarmTime.ON_TIME)
+            .alarmTime("ON_TIME")
             .participants(List.of(UserReadResponse.of(u1), UserReadResponse.of(u2)))
             .build();
         ScheduleCreateRequest r4 = ScheduleCreateRequest.builder()
@@ -850,7 +850,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .scheduleStartAt("2023-11-30 08:59:30")
             .scheduleEndAt("2023-12-01 09:00:00")
             .isAuthorizedAll(false)
-            .alarmTime(AlarmTime.ON_TIME)
+            .alarmTime("ON_TIME")
             .participants(List.of(UserReadResponse.of(u1)))
             .build();
         ScheduleCreateRequest r5 = ScheduleCreateRequest.builder()
@@ -860,7 +860,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .isAllDay(false)
             .scheduleStartAt("2023-11-30 00:00:00")
             .isAuthorizedAll(false)
-            .alarmTime(AlarmTime.ON_TIME)
+            .alarmTime("ON_TIME")
             .participants(List.of(UserReadResponse.of(u2)))
             .build();
         ScheduleCreateRequest r6 = ScheduleCreateRequest.builder()
@@ -871,7 +871,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .scheduleStartAt("2023-10-30 08:59:30")
             .scheduleEndAt("2023-12-01 09:00:00")
             .isAuthorizedAll(false)
-            .alarmTime(AlarmTime.ON_TIME)
+            .alarmTime("ON_TIME")
             .participants(List.of(UserReadResponse.of(u1)))
             .build();
         scheduleService.createSchedule(u1.getUserSeq(), r1);
@@ -944,7 +944,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .scheduleStartAt("2023-10-01 08:59:30")
             .scheduleEndAt("2023-11-01 09:00:00")
             .isAuthorizedAll(false)
-            .alarmTime(AlarmTime.NONE)
+            .alarmTime("NONE")
             .participants(List.of(
                 UserReadResponse.of(u1)))
             .build();
@@ -956,7 +956,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .scheduleStartAt("2023-11-01 08:59:30")
             .scheduleEndAt("2023-11-01 09:00:00")
             .isAuthorizedAll(false)
-            .alarmTime(AlarmTime.ON_TIME)
+            .alarmTime("ON_TIME")
             .participants(List.of(UserReadResponse.of(u1), UserReadResponse.of(u2)))
             .build();
         ScheduleCreateRequest r3 = ScheduleCreateRequest.builder()
@@ -967,7 +967,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .scheduleStartAt("2023-10-30 08:59:30")
             .scheduleEndAt("2023-10-30 09:00:00")
             .isAuthorizedAll(false)
-            .alarmTime(AlarmTime.ON_TIME)
+            .alarmTime("ON_TIME")
             .participants(List.of(UserReadResponse.of(u1), UserReadResponse.of(u2)))
             .build();
         ScheduleCreateRequest r4 = ScheduleCreateRequest.builder()
@@ -978,7 +978,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .scheduleStartAt("2023-11-30 08:59:30")
             .scheduleEndAt("2023-12-01 09:00:00")
             .isAuthorizedAll(false)
-            .alarmTime(AlarmTime.ON_TIME)
+            .alarmTime("ON_TIME")
             .participants(List.of(UserReadResponse.of(u1)))
             .build();
         ScheduleCreateRequest r5 = ScheduleCreateRequest.builder()
@@ -989,7 +989,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .scheduleStartAt("2022-11-01 08:59:30")
             .scheduleEndAt("2022-12-01 09:00:00")
             .isAuthorizedAll(false)
-            .alarmTime(AlarmTime.ON_TIME)
+            .alarmTime("ON_TIME")
             .participants(List.of(UserReadResponse.of(u2)))
             .build();
         scheduleService.createSchedule(u1.getUserSeq(), r1);
@@ -1052,7 +1052,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .isDateSelected(false)
             .isTimeSelected(false)
             .isAllDay(false)
-            .alarmTime(AlarmTime.NONE)
+            .alarmTime("NONE")
             .isAuthorizedAll(false)
             .participants(List.of(
                 UserReadResponse.of(u1), UserReadResponse.of(u2), UserReadResponse.of(u3)))
@@ -1088,7 +1088,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .isDateSelected(false)
             .isTimeSelected(false)
             .isAllDay(false)
-            .alarmTime(AlarmTime.NONE)
+            .alarmTime("NONE")
             .isAuthorizedAll(false)
             .participants(List.of(
                 UserReadResponse.of(u1), UserReadResponse.of(u2)))
@@ -1154,7 +1154,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .isAllDay(false)
             .scheduleStartAt("2023-11-01 09:00:00")
             .scheduleEndAt("2023-11-01 10:00:00")
-            .alarmTime(AlarmTime.THIRTY_MINUTES_BEFORE)
+            .alarmTime("THIRTY_MINUTES_BEFORE")
             .isAuthorizedAll(false)
             .participants(List.of(
                 UserReadResponse.of(u1), UserReadResponse.of(u2), UserReadResponse.of(u3)))
@@ -1170,12 +1170,12 @@ class ScheduleServiceTest extends IntegrationTestSupport {
         ParticipationUpdateRequest u2ParticipationUpdateRequest = ParticipationUpdateRequest.builder()
             .scheduleName("안녕 내가 일정 이름이야")
             .scheduleMemo("이거는 동기화 안되는 메모고")
-            .alarmTime(AlarmTime.ONE_HOUR_BEFORE)
+            .alarmTime("ONE_HOUR_BEFORE")
             .build();
         ParticipationUpdateRequest u3ParticipationUpdateRequest = ParticipationUpdateRequest.builder()
             .scheduleName("안녕 내가 일정 이름이야")
             .scheduleMemo("이거는 동기화 안되는 메모고")
-            .alarmTime(AlarmTime.FIFTEEN_MINUTES_BEFORE)
+            .alarmTime("FIFTEEN_MINUTES_BEFORE")
             .build();
         scheduleService.updateParticipation(u2.getUserSeq(), scheduleCreateResponse.scheduleSeq(),
             u2ParticipationUpdateRequest);
@@ -1216,7 +1216,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .isDateSelected(false)
             .isTimeSelected(false)
             .isAllDay(false)
-            .alarmTime(AlarmTime.NONE)
+            .alarmTime("NONE")
             .isAuthorizedAll(true)
             .participants(List.of(
                 UserReadResponse.of(u1), UserReadResponse.of(u2)))
@@ -1288,7 +1288,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .isDateSelected(false)
             .isTimeSelected(false)
             .isAllDay(false)
-            .alarmTime(AlarmTime.NONE)
+            .alarmTime("NONE")
             .isAuthorizedAll(false)
             .participants(List.of(
                 UserReadResponse.of(u1), UserReadResponse.of(u2), UserReadResponse.of(u3)))
@@ -1352,7 +1352,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .isDateSelected(false)
             .isAllDay(false)
             .isAuthorizedAll(false)
-            .alarmTime(AlarmTime.NONE)
+            .alarmTime("NONE")
             .participants(List.of(
                 UserReadResponse.of(u1)))
             .build();
@@ -1366,7 +1366,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
         ParticipationUpdateRequest updateRequest = ParticipationUpdateRequest.builder()
             .scheduleName("안녕 나는 바뀐 일정 이름이야")
             .scheduleMemo("이거는 동기화 안되는 메모야")
-            .alarmTime(AlarmTime.NONE)
+            .alarmTime("NONE")
             .categorySeq(category.getCategorySeq())
             .build();
 
@@ -1408,7 +1408,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .isDateSelected(false)
             .isAllDay(false)
             .isAuthorizedAll(false)
-            .alarmTime(AlarmTime.NONE)
+            .alarmTime("NONE")
             .participants(List.of(
                 UserReadResponse.of(u1)))
             .categorySeq(category.getCategorySeq())
@@ -1421,7 +1421,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .scheduleStartAt("2023-11-01 08:59:30")
             .scheduleEndAt("2023-11-01 09:00:00")
             .isAuthorizedAll(false)
-            .alarmTime(AlarmTime.ON_TIME)
+            .alarmTime("ON_TIME")
             .participants(List.of(UserReadResponse.of(u1)))
             .categorySeq(category.getCategorySeq())
             .build();
@@ -1432,7 +1432,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
         ParticipationUpdateRequest updateRequest = ParticipationUpdateRequest.builder()
             .scheduleName("안녕 나는 바뀐 일정 이름이야")
             .scheduleMemo("이거는 동기화 안되는 메모야")
-            .alarmTime(AlarmTime.NONE)
+            .alarmTime("NONE")
             .categorySeq(null)
             .build();
 
@@ -1475,7 +1475,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .isDateSelected(false)
             .isTimeSelected(false)
             .isAllDay(false)
-            .alarmTime(AlarmTime.NONE)
+            .alarmTime("NONE")
             .isAuthorizedAll(false)
             .participants(List.of(
                 UserReadResponse.of(u1), UserReadResponse.of(u2)))
@@ -1514,7 +1514,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .isDateSelected(false)
             .isTimeSelected(false)
             .isAllDay(false)
-            .alarmTime(AlarmTime.NONE)
+            .alarmTime("NONE")
             .isAuthorizedAll(false)
             .participants(List.of(
                 UserReadResponse.of(u1), UserReadResponse.of(u2)))
@@ -1552,7 +1552,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .isDateSelected(false)
             .isTimeSelected(false)
             .isAllDay(false)
-            .alarmTime(AlarmTime.NONE)
+            .alarmTime("NONE")
             .isAuthorizedAll(false)
             .participants(List.of(
                 UserReadResponse.of(user)))
@@ -1587,7 +1587,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .isDateSelected(false)
             .isTimeSelected(false)
             .isAllDay(false)
-            .alarmTime(AlarmTime.NONE)
+            .alarmTime("NONE")
             .isAuthorizedAll(false)
             .participants(List.of(
                 UserReadResponse.of(user)))
@@ -1706,7 +1706,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .isDateSelected(false)
             .isAllDay(false)
             .isAuthorizedAll(false)
-            .alarmTime(AlarmTime.NONE)
+            .alarmTime("NONE")
             .participants(List.of(
                 UserReadResponse.of(u1)))
             .categorySeq(category.getCategorySeq())
@@ -1739,7 +1739,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .isDateSelected(true)
             .isTimeSelected(false)
             .isAllDay(false)
-            .alarmTime(AlarmTime.NONE)
+            .alarmTime("NONE")
             .isAuthorizedAll(true)
             .participants(List.of(
                 UserReadResponse.of(user1), UserReadResponse.of(user2)))
@@ -1768,7 +1768,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .isTimeSelected(true)
             .scheduleStartAt("2023-11-01 08:59:30")
             .isAllDay(false)
-            .alarmTime(AlarmTime.NONE)
+            .alarmTime("NONE")
             .isAuthorizedAll(true)
             .participants(List.of(
                 UserReadResponse.of(user1), UserReadResponse.of(user2)))
@@ -1810,7 +1810,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .isDateSelected(false)
             .isAllDay(false)
             .isAuthorizedAll(false)
-            .alarmTime(AlarmTime.NONE)
+            .alarmTime("NONE")
             .participants(List.of(
                 UserReadResponse.of(user1), UserReadResponse.of(user2)))
             .build();
@@ -1846,7 +1846,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .isDateSelected(false)
             .isAllDay(false)
             .isAuthorizedAll(false)
-            .alarmTime(AlarmTime.NONE)
+            .alarmTime("NONE")
             .participants(List.of(
                 UserReadResponse.of(u1)))
             .build();
@@ -1890,7 +1890,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .isDateSelected(false)
             .isAllDay(false)
             .isAuthorizedAll(false)
-            .alarmTime(AlarmTime.NONE)
+            .alarmTime("NONE")
             .participants(List.of(
                 UserReadResponse.of(u1)))
             .build();
@@ -1931,7 +1931,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .isDateSelected(false)
             .isAllDay(false)
             .isAuthorizedAll(false)
-            .alarmTime(AlarmTime.NONE)
+            .alarmTime("NONE")
             .participants(List.of(
                 UserReadResponse.of(u1), UserReadResponse.of(u2)))
             .build();
@@ -1966,7 +1966,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .isDateSelected(false)
             .isAllDay(false)
             .isAuthorizedAll(false)
-            .alarmTime(AlarmTime.NONE)
+            .alarmTime("NONE")
             .participants(List.of(
                 UserReadResponse.of(u1), UserReadResponse.of(u2)))
             .build();
@@ -1999,7 +1999,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .isDateSelected(false)
             .isAllDay(false)
             .isAuthorizedAll(false)
-            .alarmTime(AlarmTime.NONE)
+            .alarmTime("NONE")
             .participants(List.of(
                 UserReadResponse.of(user)))
             .build();
@@ -2029,7 +2029,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .isDateSelected(false)
             .isAllDay(false)
             .isAuthorizedAll(false)
-            .alarmTime(AlarmTime.NONE)
+            .alarmTime("NONE")
             .participants(List.of(
                 UserReadResponse.of(u1), UserReadResponse.of(u2)))
             .build();
@@ -2059,7 +2059,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .isDateSelected(false)
             .isTimeSelected(false)
             .isAllDay(false)
-            .alarmTime(AlarmTime.NONE)
+            .alarmTime("NONE")
             .isAuthorizedAll(false)
             .participants(List.of(
                 UserReadResponse.of(user)))
@@ -2089,7 +2089,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .isDateSelected(false)
             .isTimeSelected(false)
             .isAllDay(false)
-            .alarmTime(AlarmTime.NONE)
+            .alarmTime("NONE")
             .isAuthorizedAll(false)
             .participants(List.of(
                 UserReadResponse.of(user)))
@@ -2125,7 +2125,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .isDateSelected(false)
             .isTimeSelected(false)
             .isAllDay(false)
-            .alarmTime(AlarmTime.NONE)
+            .alarmTime("NONE")
             .isAuthorizedAll(false)
             .participants(List.of(
                 UserReadResponse.of(u1)))
@@ -2178,7 +2178,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .scheduleStartAt("2023-10-01 08:59:30")
             .scheduleEndAt("2023-11-01 09:00:00")
             .isAuthorizedAll(false)
-            .alarmTime(AlarmTime.NONE)
+            .alarmTime("NONE")
             .participants(List.of(
                 UserReadResponse.of(u1)))
             .build();
@@ -2190,7 +2190,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .scheduleStartAt("2023-11-01 08:59:30")
             .scheduleEndAt("2023-11-01 09:00:00")
             .isAuthorizedAll(false)
-            .alarmTime(AlarmTime.ON_TIME)
+            .alarmTime("ON_TIME")
             .participants(List.of(UserReadResponse.of(u1), UserReadResponse.of(u2)))
             .build();
         ScheduleCreateRequest r3 = ScheduleCreateRequest.builder()
@@ -2201,7 +2201,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .scheduleStartAt("2023-10-30 08:59:30")
             .scheduleEndAt("2023-10-30 09:00:00")
             .isAuthorizedAll(false)
-            .alarmTime(AlarmTime.ON_TIME)
+            .alarmTime("ON_TIME")
             .participants(List.of(UserReadResponse.of(u1), UserReadResponse.of(u2)))
             .build();
         ScheduleCreateRequest r4 = ScheduleCreateRequest.builder()
@@ -2212,7 +2212,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .scheduleStartAt("2023-11-30 08:59:30")
             .scheduleEndAt("2023-12-01 09:00:00")
             .isAuthorizedAll(false)
-            .alarmTime(AlarmTime.ON_TIME)
+            .alarmTime("ON_TIME")
             .participants(List.of(UserReadResponse.of(u1)))
             .build();
         ScheduleCreateRequest r5 = ScheduleCreateRequest.builder()
@@ -2223,7 +2223,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .scheduleStartAt("2023-11-30 08:59:30")
             .scheduleEndAt("2023-12-01 09:00:00")
             .isAuthorizedAll(false)
-            .alarmTime(AlarmTime.ON_TIME)
+            .alarmTime("ON_TIME")
             .participants(List.of(UserReadResponse.of(u2)))
             .build();
         scheduleService.createSchedule(u1.getUserSeq(), r1);
@@ -2260,7 +2260,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .scheduleStartAt("2023-10-01 08:59:30")
             .scheduleEndAt("2023-11-01 09:00:00")
             .isAuthorizedAll(false)
-            .alarmTime(AlarmTime.NONE)
+            .alarmTime("NONE")
             .participants(List.of(
                 UserReadResponse.of(u1)))
             .build();
@@ -2272,7 +2272,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .scheduleStartAt("2023-11-01 08:59:30")
             .scheduleEndAt("2023-11-01 09:00:00")
             .isAuthorizedAll(false)
-            .alarmTime(AlarmTime.ON_TIME)
+            .alarmTime("ON_TIME")
             .participants(List.of(UserReadResponse.of(u1), UserReadResponse.of(u2)))
             .build();
         ScheduleCreateRequest r3 = ScheduleCreateRequest.builder()
@@ -2283,7 +2283,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .scheduleStartAt("2023-10-30 08:59:30")
             .scheduleEndAt("2023-10-30 09:00:00")
             .isAuthorizedAll(false)
-            .alarmTime(AlarmTime.ON_TIME)
+            .alarmTime("ON_TIME")
             .participants(List.of(UserReadResponse.of(u1), UserReadResponse.of(u2)))
             .build();
         ScheduleCreateRequest r4 = ScheduleCreateRequest.builder()
@@ -2294,7 +2294,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .scheduleStartAt("2023-11-30 08:59:30")
             .scheduleEndAt("2023-12-01 09:00:00")
             .isAuthorizedAll(false)
-            .alarmTime(AlarmTime.ON_TIME)
+            .alarmTime("ON_TIME")
             .participants(List.of(UserReadResponse.of(u1)))
             .build();
         ScheduleCreateRequest r5 = ScheduleCreateRequest.builder()
@@ -2305,7 +2305,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .scheduleStartAt("2023-11-30 08:59:30")
             .scheduleEndAt("2023-12-01 09:00:00")
             .isAuthorizedAll(false)
-            .alarmTime(AlarmTime.ON_TIME)
+            .alarmTime("ON_TIME")
             .participants(List.of(UserReadResponse.of(u2)))
             .build();
         scheduleService.createSchedule(u1.getUserSeq(), r1);
@@ -2425,7 +2425,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .isDateSelected(false)
             .isTimeSelected(false)
             .isAllDay(false)
-            .alarmTime(AlarmTime.NONE)
+            .alarmTime("NONE")
             .isAuthorizedAll(false)
             .participants(List.of(
                 UserReadResponse.of(user)))
@@ -2457,7 +2457,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .isDateSelected(false)
             .isTimeSelected(false)
             .isAllDay(false)
-            .alarmTime(AlarmTime.NONE)
+            .alarmTime("NONE")
             .isAuthorizedAll(false)
             .participants(List.of(
                 UserReadResponse.of(user)))
@@ -2501,7 +2501,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .isDateSelected(false)
             .isTimeSelected(false)
             .isAllDay(false)
-            .alarmTime(AlarmTime.NONE)
+            .alarmTime("NONE")
             .isAuthorizedAll(false)
             .participants(List.of(
                 UserReadResponse.of(user)))
@@ -2533,7 +2533,7 @@ class ScheduleServiceTest extends IntegrationTestSupport {
             .isDateSelected(false)
             .isTimeSelected(false)
             .isAllDay(false)
-            .alarmTime(AlarmTime.NONE)
+            .alarmTime("NONE")
             .isAuthorizedAll(false)
             .participants(List.of(
                 UserReadResponse.of(user)))


### PR DESCRIPTION
## 개요
- 일정 생성, 참가정보 수정 시 request body에 알림 시간의 자료형을 `AlarmType`에서 `String`으로 교체했습니다.
- 이제 알림 시간이 `15분 전`이라면 request 시에 `"FIFTEEN_MINUTES_BEFORE"`를 보내고, response로 `"15분 전"`을 받을 수 있습니다.

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).