### PR TITLE
Fix: 공통 컴포넌트 수정

### DIFF
--- a/frontend/_packages/@external-temporal/components/interaction/Btn/Btn.stories.ts
+++ b/frontend/_packages/@external-temporal/components/interaction/Btn/Btn.stories.ts
@@ -23,7 +23,7 @@ const meta = {
         '버튼의 작동 여부를 정합니다. 클릭을 막고 싶다면 true를 선택해주세요.',
     },
     children: {
-      description: '자식 노드를 받습니다. 텍스트 노드 사용을 권고합니다.',
+      description: '자식 노드를 받습니다.',
     },
     onClick: {
       description: '클릭 시 실행될 함수입니다.',

--- a/frontend/_packages/@external-temporal/components/interaction/Btn/Btn.tsx
+++ b/frontend/_packages/@external-temporal/components/interaction/Btn/Btn.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
-import type { HTMLAttributes, MouseEvent } from 'react';
+import type { HTMLAttributes, MouseEvent, ReactNode } from 'react';
 
 import { VARIANTS } from './Btn.css';
 
 export interface BtnProps extends HTMLAttributes<HTMLButtonElement> {
   type: 'button' | 'submit';
   variant: keyof typeof VARIANTS;
-  disabled: boolean;
+  disabled?: boolean;
   onClick?: (e: MouseEvent) => void;
-  children: string;
+  children: ReactNode;
 }
 
 export function Btn({ type, variant, disabled, onClick, children }: BtnProps) {

--- a/frontend/_packages/@external-temporal/components/interaction/BtnRound/BtnRound.stories.ts
+++ b/frontend/_packages/@external-temporal/components/interaction/BtnRound/BtnRound.stories.ts
@@ -26,7 +26,7 @@ const meta = {
         '버튼의 작동 여부를 정합니다. 클릭을 막고 싶다면 true를 선택해주세요.',
     },
     children: {
-      description: '자식 노드를 받습니다. 텍스트 노드 사용을 권고합니다.',
+      description: '자식 노드를 받습니다.',
     },
     onClick: {
       description: '클릭 시 실행될 함수입니다.',

--- a/frontend/_packages/@external-temporal/components/interaction/BtnRound/BtnRound.tsx
+++ b/frontend/_packages/@external-temporal/components/interaction/BtnRound/BtnRound.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
-import type { HTMLAttributes, MouseEvent } from 'react';
+import type { HTMLAttributes, MouseEvent, ReactNode } from 'react';
 import { SIZE, VARIANTS } from './BtnRound.css';
 
 export interface BtnRoundProps extends HTMLAttributes<HTMLButtonElement> {
   type: 'button' | 'submit';
   variant: keyof typeof VARIANTS;
   size?: keyof typeof SIZE;
-  disabled: boolean;
+  disabled?: boolean;
   onClick?: (e: MouseEvent) => void;
-  children: string;
+  children: ReactNode;
 }
 export function BtnRound({
   type,

--- a/frontend/_packages/@external-temporal/components/interaction/Chip/Chip.css.ts
+++ b/frontend/_packages/@external-temporal/components/interaction/Chip/Chip.css.ts
@@ -27,7 +27,12 @@ export const TYPE_VARIANT = styleVariants({
   ],
   filterselected: [
     BASE,
-    { backgroundColor: colors.key, color: colors.WHITE, cursor: 'pointer' },
+    {
+      border: `1px solid transparent`,
+      backgroundColor: colors.key,
+      color: colors.WHITE,
+      cursor: 'pointer',
+    },
   ],
   keyword: [
     BASE,

--- a/frontend/_packages/@external-temporal/components/interaction/Chip/Chip.stories.ts
+++ b/frontend/_packages/@external-temporal/components/interaction/Chip/Chip.stories.ts
@@ -27,7 +27,7 @@ const meta = {
     label: {
       description: '바인딩 될 input 태그의 id입니다.',
     },
-    onFlitered: {
+    onFiltered: {
       description: '필터 칩이 선택되었을 때 해당 값을 함수로 전달합니다.',
     },
     onDelete: {

--- a/frontend/_packages/@external-temporal/components/interaction/Chip/Chip.tsx
+++ b/frontend/_packages/@external-temporal/components/interaction/Chip/Chip.tsx
@@ -6,7 +6,7 @@ interface Props {
   type: keyof typeof TYPE_VARIANT;
   label: string;
   shape?: keyof typeof SHAPE_VARIANT;
-  onFlitered?: (label: string) => void;
+  onFiltered?: (label: string) => void;
   onDelete?: (label: string) => void;
 }
 
@@ -14,7 +14,7 @@ export function Chip({
   type,
   label,
   shape = 'round',
-  onFlitered,
+  onFiltered,
   onDelete,
 }: Props) {
   const classname = `${TYPE_VARIANT[type]} ${SHAPE_VARIANT[shape]}`;
@@ -23,7 +23,7 @@ export function Chip({
       return (
         <span
           className={classname}
-          onClick={() => onFlitered && onFlitered(label)}
+          onClick={() => onFiltered && onFiltered(label)}
         >
           {label}
         </span>
@@ -32,7 +32,7 @@ export function Chip({
       return (
         <span
           className={classname}
-          onClick={() => onFlitered && onFlitered(label)}
+          onClick={() => onFiltered && onFiltered(label)}
         >
           {label}
         </span>

--- a/frontend/_packages/@external-temporal/components/interaction/Input/Input.stories.ts
+++ b/frontend/_packages/@external-temporal/components/interaction/Input/Input.stories.ts
@@ -7,7 +7,7 @@ const meta = {
   title: 'External-temporal/Interaction/Form/Input',
   component: Input,
   parameters: {
-    componentSubtitle: 'text와 checkbox 타입을 지원하는 input 태그입니다.',
+    componentSubtitle: 'text와 checkbox 타입을 지원하는 input 컴포넌트입니다.',
   },
   tags: ['autodocs'],
   argTypes: {

--- a/frontend/_packages/@external-temporal/components/interaction/Input/Input.tsx
+++ b/frontend/_packages/@external-temporal/components/interaction/Input/Input.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import type { HTMLAttributes } from 'react';
+import type { FocusEvent, HTMLAttributes, KeyboardEvent } from 'react';
 
 import { ChangeEvent } from 'react';
 import { TYPE } from './Input.css';
@@ -10,7 +10,9 @@ export interface InputProps extends HTMLAttributes<HTMLInputElement> {
   id: string;
   name: string;
   onChange: (e: ChangeEvent<HTMLInputElement>) => void;
-  disabled: boolean;
+  onKeyDown?: (e: KeyboardEvent) => void;
+  onFocus?: (e: FocusEvent) => void;
+  disabled?: boolean;
   placeholder?: string;
   value: string;
   checked?: boolean;
@@ -23,6 +25,8 @@ export function Input({
   id,
   name,
   onChange,
+  onKeyDown = e => {},
+  onFocus = e => {},
   disabled,
   placeholder = '',
   value,
@@ -38,6 +42,8 @@ export function Input({
       id={id}
       name={name}
       onChange={e => validator(e.target.value) && onChange(e)}
+      onKeyDown={e => onKeyDown(e)}
+      onFocus={e => onFocus(e)}
       placeholder={placeholder}
       type={type}
       value={value}

--- a/frontend/_packages/@external-temporal/components/interaction/Textarea/Textarea.css.ts
+++ b/frontend/_packages/@external-temporal/components/interaction/Textarea/Textarea.css.ts
@@ -4,7 +4,7 @@ import { style, styleVariants } from '@vanilla-extract/css';
 const BASE = style({
   backgroundColor: colors.GREY_200,
   border: 'none',
-  borderRadius: '0.25rem',
+  borderRadius: '0.5rem',
   color: colors.black,
   padding: '0.75rem',
   width: '100%',

--- a/frontend/_packages/@external-temporal/components/interaction/Textarea/Textarea.tsx
+++ b/frontend/_packages/@external-temporal/components/interaction/Textarea/Textarea.tsx
@@ -1,20 +1,27 @@
 import React from 'react';
-import type { HTMLAttributes } from 'react';
+import type { ChangeEvent, FormEvent, HTMLAttributes } from 'react';
 import { SIZE } from './Textarea.css';
 
 export interface TextAreaProps extends HTMLAttributes<HTMLTextAreaElement> {
   value: string;
   placeholder: string;
   height: keyof typeof SIZE;
+  onChange: (event: ChangeEvent<HTMLTextAreaElement>) => void;
 }
 
-export function Textarea({ value, placeholder, height }: TextAreaProps) {
+export function Textarea({
+  value,
+  placeholder,
+  height,
+  onChange,
+}: TextAreaProps) {
   return (
     <textarea
       className={SIZE[height]}
       placeholder={placeholder}
       value={value}
       wrap="on"
+      onChange={onChange}
     />
   );
 }


### PR DESCRIPTION
## 개요

- 공통 컴포넌트를 수정합니다.
- Btn, BtnRound 컴포넌트의 children prop이 string에서 ReactNode를 받을 수 있도록 변경합니다.
- Ban, BtnRound, Input 컴포넌트의 disabled 값이 필수 prop이 아니도록 변경합니다.
- Input이 onKeyDown과 onFocus를 받을 수 있습니다.
- Chip type=suggestion의 색깔을 key로 변경합니다.
- Textarea의 border-radius의 radius를 다른 컴포넌트와 통일합니다.
- Textarea가 onChange 함수를 사용할 수 있도록 변경합니다.

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).