### PR TITLE
Fix: servertime 호출 시점에 따른 오류 해결

### DIFF
--- a/frontend/_apps/schedule/components/MobileCalendar/MobileCalendarDate/MobileCalendarDate.tsx
+++ b/frontend/_apps/schedule/components/MobileCalendar/MobileCalendarDate/MobileCalendarDate.tsx
@@ -9,6 +9,7 @@ import {
   ScheduleSearchResponse,
 } from 'amadda-global-types';
 import { useCategoryStore } from '@SCH/store/categoryStore';
+import useServerTime from '@SCH/hooks/useServerTime';
 
 export interface DateInfo {
   year: string;
@@ -18,6 +19,7 @@ export interface DateInfo {
 
 export function MobileCalendarDate() {
   // 전역 store에서 연월 정보 가져오기
+  useServerTime();
   const { selectedYear, selectedMonth, selectedDate } = useDateStore();
   const { selectedCategorySeq, selectedAll, selectedNone } = useCategoryStore();
   const {

--- a/frontend/_apps/schedule/hooks/useScheduleList.ts
+++ b/frontend/_apps/schedule/hooks/useScheduleList.ts
@@ -45,7 +45,8 @@ export function useMonthlySchedule() {
   const [monthlyScheduleList, setMonthlyScheduleList] =
     useState<ScheduleSearchResponse>({});
   const { selectedYear, selectedMonth } = useDateStore();
-  const { data, error, isLoading } = useSWR('/api/schedule?', () =>
+
+  const { data, error, isLoading } = useSWR('/api/schedule', () =>
     scheduleList({ year: selectedYear, month: selectedMonth })
   );
 
@@ -60,7 +61,7 @@ export function useDailySchedule() {
   >([]);
   const { selectedYear, selectedMonth, selectedDate } = useDateStore();
 
-  const { data, error, isLoading } = useSWR('/api/schedule?', () =>
+  const { data, error, isLoading } = useSWR('/api/schedule', () =>
     scheduleList({
       year: selectedYear,
       month: selectedMonth,
@@ -84,7 +85,7 @@ export function useUnscheduled() {
   const [unscheduledList, setUnscheduledList] = useState<
     Array<ScheduleListReadResponse>
   >([]);
-  const { data, error, isLoading } = useSWR('/api/schedule?', () =>
+  const { data, error, isLoading } = useSWR('/api/schedule', () =>
     scheduleList({ unscheduled: true })
   );
 


### PR DESCRIPTION
## 개요
최초 데이터를 가져오기 위한 `useServertime()`을 올바르지 못한 곳에서 호출하여 하위 컴포넌트 로딩 시 데이터가 온전히 fetch 되지 않는 문제가 발생했습니다.
이에 `useServertime()`를 하위 데이터를 로드하는 컴포넌트에 추가하였습니다.

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).