### PR TITLE
Fix: Bearer 문자열이 두 번 겹쳐서 가지 않도록 수정

### DIFF
--- a/frontend/_packages/connection/https.ts
+++ b/frontend/_packages/connection/https.ts
@@ -5,7 +5,7 @@ export const https = {
     axios
       .get<Response>(url, {
         headers: {
-          Authorization: `Bearer ${token}`,
+          Authorization: `${token}`,
         },
       })
       .then(res => res),
@@ -17,7 +17,7 @@ export const https = {
     axios
       .post<Response>(url, body, {
         headers: {
-          Authorization: `Bearer ${token}`,
+          Authorization: `${token}`,
         },
       })
       .then(res => res),
@@ -29,7 +29,7 @@ export const https = {
     axios
       .put<Response>(url, body, {
         headers: {
-          Authorization: `Bearer ${token}`,
+          Authorization: `${token}`,
         },
       })
       .then(res => res),
@@ -41,7 +41,7 @@ export const https = {
     axios
       .patch<Response>(url, body, {
         headers: {
-          Authorization: `Bearer ${token}`,
+          Authorization: `${token}`,
         },
       })
       .then(res => res),
@@ -49,7 +49,7 @@ export const https = {
     axios
       .delete<Response>(url, {
         headers: {
-          Authorization: `Bearer ${token}`,
+          Authorization: `${token}`,
         },
       })
       .then(res => res),


### PR DESCRIPTION
## 개요

- header에 있는 token 문자열에 이미 `Bearer`가 포함되어 있는데 중복해서 쓰고 있는 문제를 해결합니다.

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).