### PR TITLE
Fix: 카테고리 api path 오류로 인한 도메인 이동

### DIFF
--- a/frontend/_apps/schedule/components/ScheduleEdit/ScheduleEditData.ts
+++ b/frontend/_apps/schedule/components/ScheduleEdit/ScheduleEditData.ts
@@ -109,7 +109,7 @@ export function ScheduleEditData(props: {
   const [categoryInput, setCategoryInput] = useState<string>('');
 
   const getCategory = () =>
-    fetch(`${process.env.NEXT_PUBLIC_USER}/api/user/category`, {
+    fetch(`${process.env.NEXT_PUBLIC_SCHEDULE}/api/schedule/user/category`, {
       headers: {
         'Content-Type': 'application/json',
       },

--- a/frontend/_apps/schedule/hooks/useCategory.ts
+++ b/frontend/_apps/schedule/hooks/useCategory.ts
@@ -8,13 +8,16 @@ import { CategoryReadResponse } from 'amadda-global-types';
 const fetcher = url =>
   http
     .get<Array<CategoryReadResponse>>(
-      `${process.env.NEXT_PUBLIC_USER}/api/user/category`
+      `${process.env.NEXT_PUBLIC_SCHEDULE}/api/schedule/user/category`
     )
     .then(res => res.data);
 
 export default function useCategory() {
   const [categories, setCategories] = useState<Array<CategoryReadResponse>>([]);
-  const { data, error, isLoading } = useSWR('/api/user/category', fetcher);
+  const { data, error, isLoading } = useSWR(
+    '/api/schedule/user/category',
+    fetcher
+  );
 
   useEffect(() => {
     data && setCategories(data);

--- a/frontend/_apps/schedule/pages/api/schedule/user/category.ts
+++ b/frontend/_apps/schedule/pages/api/schedule/user/category.ts
@@ -11,7 +11,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     //해당 사용자의 카테고리 목록 띄워주기
     try {
       const SPRING_RES = await https.get<Array<CategoryReadResponse>>(
-        `${process.env.SPRING_API_ROOT}/user/category`,
+        `${process.env.SPRING_API_ROOT}/schedule/user/category`,
         token
       );
       res.status(SPRING_RES.status).json(SPRING_RES.data);
@@ -26,7 +26,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     //카테고리 생성
     try {
       const SPRING_RES = await https.post<CategoryCreateResponse>(
-        `${process.env.SPRING_API_ROOT}/user/category`,
+        `${process.env.SPRING_API_ROOT}/schedule/user/category`,
         token,
         req.body
       );

--- a/frontend/_apps/schedule/pages/api/schedule/user/category/[categorySeq].ts
+++ b/frontend/_apps/schedule/pages/api/schedule/user/category/[categorySeq].ts
@@ -9,7 +9,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     //카테고리 수정 (이름/색깔)
     try {
       const SPRING_RES = await https.put<CategoryUpdateResponse>(
-        `${process.env.SPRING_API_ROOT}/user/category/${categorySeq}`,
+        `${process.env.SPRING_API_ROOT}/schedule/user/category/${categorySeq}`,
         token,
         req.body
       );
@@ -25,7 +25,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     //카테고리 삭제
     try {
       const SPRING_RES = await https.delete(
-        `${process.env.SPRING_API_ROOT}/user/category/${categorySeq}`,
+        `${process.env.SPRING_API_ROOT}/schedule/user/category/${categorySeq}`,
         token
       );
       res.status(SPRING_RES.status).json(SPRING_RES.data);

--- a/frontend/_apps/shell/components/Header/Header.css.ts
+++ b/frontend/_apps/shell/components/Header/Header.css.ts
@@ -9,7 +9,7 @@ export const BASE = style({
 });
 export const ICON = style({});
 export const MENU = style({
-  width: '3rem',
+  width: '2.5rem',
   height: '2.25rem',
   background: 'transparent',
   border: 'none',


### PR DESCRIPTION
## 개요

- `user/category/...` -> `schedule/user/category/...` 로 변경합니다.
- 이에 따라 api 도메인 위치를 user에서 schedule로 변경합니다.
- 헤더 컴포넌트의 버튼 width를 소폭 축소합니다.

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).