### PR TITLE
Fix: css flex mixed-support 문제 해결

### DIFF
--- a/frontend/_packages/@external-temporal/components/layout/Flex.css.ts
+++ b/frontend/_packages/@external-temporal/components/layout/Flex.css.ts
@@ -17,9 +17,11 @@ export const JUSTIFY_VARIANT = styleVariants({
 });
 
 export const ALIGN_VARIANT = styleVariants({
-  start: { alignItems: 'start' },
+  start: { alignItems: 'flex-start' },
+  end: { alignItems: 'flex-end' },
+  flexStart: { alignItems: 'flex-start' },
+  flexEnd: { alignItems: 'flex-end' },
   center: { alignItems: 'center' },
-  end: { alignItems: 'end' },
   stretch: { alignItems: 'stretch' },
 });
 

--- a/frontend/_packages/@external-temporal/components/layout/Flex.css.ts
+++ b/frontend/_packages/@external-temporal/components/layout/Flex.css.ts
@@ -8,8 +8,10 @@ export const DIRECTION_VARIANT = styleVariants({
 });
 
 export const JUSTIFY_VARIANT = styleVariants({
-  start: { justifyContent: 'start' },
+  start: { justifyContent: 'flex-start' },
+  end: { justifyContent: 'flex-end' },
   center: { justifyContent: 'center' },
+  flexStart: { justifyContent: 'flex-start' },
   flexEnd: { justifyContent: 'flex-end' },
   spaceBetween: { justifyContent: 'space-between' },
   spaceAround: { justifyContent: 'space-around' },


### PR DESCRIPTION
## 개요

- next.js가 css를 처리하는 과정에서 `align-items`나 `justify-content` 프로퍼티에 `end`, `start` value가 들어오면, `flex-end`, `flex-start`를 사용하라는 경고를 띄웁니다. 해당 문제를 해결합니다. (https://nextjs.org/docs/pages/building-your-application/configuring/post-css)
<img width="778" alt="스크린샷 2023-11-29 13 59 32" src="https://github.com/pp-pppp/amadda/assets/82228797/4ecec260-7eb1-4bdf-9a82-a739f5dba1a7">

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).