### PR TITLE
Feat: 인증 실패 시 명시적으로 만료된 쿠키를 브라우저에서 삭제한 후 리다이렉트

### DIFF
--- a/frontend/_packages/connection/auth.ts
+++ b/frontend/_packages/connection/auth.ts
@@ -2,57 +2,49 @@ import { UserAccessResponse, UserJwtResponse } from 'amadda-global-types';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import * as Sentry from '@sentry/nextjs';
 import { kv } from './kv';
+import { kakaoAuth } from './kakaoAuth';
+import { https } from './https';
 
 type API_HANDLER = (request: NextApiRequest, response: NextApiResponse) => Promise<NextApiResponse | void>;
 
+/**
+ * 클라이언트 사이드의 통신 규격은 쿠키, 서버 사이드의 통신 규격은 Bearer Auth입니다.
+ * 따라서 next.js에서는 클라이언트 요청을 spring으로 보낼 때 쿠키를 header로 변환하고,
+ * 응답을 받아 쿠키를 지속적으로 갱신해줘야 합니다.
+ */
 export function auth(fn: API_HANDLER): API_HANDLER {
   return async function (req: NextApiRequest, res: NextApiResponse) {
-    //auth는 api 핸들러를 받아 인증 처리를 한 API 결과를 리턴합니다.
-    const CLIENT_TOKEN = req.cookies.Auth || '';
-    //클라이언트에서 보낸 쿠키의 access token을 가져옵니다.
-    if (!req.cookies.Auth) return res.redirect(`${process.env.NEXT_PUBLIC_SHELL}/signout`); //만약 쿠키의 액세스 토큰이 없다면 로그아웃시킵니다.
-
+    let ACCESS_TOKEN = req.cookies.Auth || '';
+    if (!req.cookies.Auth) {
+      return res.redirect(`${process.env.NEXT_PUBLIC_SHELL}`);
+    }
     try {
-      const ACCESS_TOKEN = await VERIFIED_TOKEN(CLIENT_TOKEN);
-      //현재 토큰이 유효하면 현재 토큰, 아니라면 새 토큰이 들어옵니다.
+      ACCESS_TOKEN = await VERIFIED_TOKEN(ACCESS_TOKEN);
       req.headers.authorization = `Bearer ${ACCESS_TOKEN}`;
       await fn(req, res);
       return res.setHeader('Set-Cookie', `Auth=${ACCESS_TOKEN}; Max-Age=900; HttpOnly; SameSite=Lax;`);
     } catch (err) {
-      //모든 종류의 에러는 로그아웃으로 리다이렉트시킵니다.
       Sentry.captureException(err);
-      return res.redirect(`${process.env.NEXT_PUBLIC_SHELL}/signout`);
+      res.setHeader('Set-Cookie', `Auth=; Max-Age=0;`);
+      return res.redirect(`${process.env.NEXT_PUBLIC_SHELL}`);
     }
   };
 }
 
 async function VERIFY(type: 'access' | 'refresh', token: string): Promise<any> {
-  const response = await fetch(`${process.env.SPRING_API_ROOT as string}/user/${type}`, {
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${token}`,
-    },
-  });
-  if (!response.ok) throw new Error(response.statusText);
-  return await response.json();
+  const BEARER_TOKEN = `Bearer ${token}`;
+  const { code, message, data } = await https.get(`${process.env.SPRING_API_ROOT as string}/user/${type}`, BEARER_TOKEN);
+  return data;
 }
 
-async function VERIFIED_TOKEN(accessToken: string) {
+async function VERIFIED_TOKEN(accessToken: string): Promise<string> {
   const inspect_AT: UserAccessResponse = await VERIFY('access', accessToken);
-  //엑세스 토큰에 대한 검증 요청을 보냅니다.
   if (inspect_AT.isBroken || !inspect_AT) throw new Error('Broken Token');
-  //토큰이 손상되었다면 exception을 던집니다.
   if (inspect_AT.isExpired) {
-    //토큰 시간이 만료된 것이라면 리프레시 토큰을 확인할 수 있는 key가 제공됩니다.
     const RT = (await kv.getToken(inspect_AT.refreshAccessKey)) || '';
-    //리프레시 토큰은 레디스(vercel kv)에 저장되어 있습니다. 레디스에서 key를 통해 토큰을 꺼냅니다.
     const inspect_RT: UserJwtResponse = await VERIFY('refresh', RT);
-    //리프레시 토큰에 대한 검증 요청을 보냅니다.
     kv.setToken(inspect_RT.refreshAccessKey, inspect_RT.refreshToken);
-    //검증 응답이 잘 왔다면 새 리프레시 토큰을 레디스(vercel kv)에 저장하고,
     return inspect_RT.accessToken;
-    //새로운 액세스 토큰을 넣어서 리턴합니다.
   }
   return accessToken;
-  //기존 엑세스 토큰에 문제가 없었다면 그대로 리턴합니다.
 }


### PR DESCRIPTION
## 개요

- 인증에 실패했을 때 로그아웃 페이지로 리다이렉트하던 것을 메인 페이지로 리다이렉트하는 것으로 변경합니다. 로그아웃 페이지에서 자동으로 로그아웃이 트리거되지 않기 때문입니다.
- 만료되거나 잘못된 액세스 토큰이 있다면 해당 토큰을 삭제한 후 메인 페이지로 리다이렉트시킵니다.
- 불필요한 로직 주석을 삭제합니다.

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).