### PR TITLE
Chore: 웹팩이 에러를 낼 때만 로그를 남기도록 설정

### DIFF
--- a/frontend/apps/notice/next.config.js
+++ b/frontend/apps/notice/next.config.js
@@ -35,6 +35,9 @@ module.exports = withVanillaExtract({
     ];
   },
   webpack(config, options) {
+    config.infrastructureLogging = {
+      level: 'error',
+    };
     if (!options.isServer) {
       config.plugins.push(
         new NextFederationPlugin({

--- a/frontend/apps/schedule/next.config.js
+++ b/frontend/apps/schedule/next.config.js
@@ -35,6 +35,9 @@ module.exports = withVanillaExtract({
     ];
   },
   webpack(config, options) {
+    config.infrastructureLogging = {
+      level: 'error',
+    };
     if (!options.isServer) {
       config.plugins.push(
         new NextFederationPlugin({
@@ -42,8 +45,9 @@ module.exports = withVanillaExtract({
           filename: 'static/chunks/entry.js',
           exposes: {
             './Calendar': './pages/mobile-main/index',
-            './Detail': './pages/schedule/[id]/index',
-            './Edit': './pages/edit/index',
+            './Detail': './pages/schedule/[scheduleSeq]/index',
+            './Create': './pages/create/index',
+            './Update': './pages/schedule/[scheduleSeq]/update/index',
           },
           shared: {
             next: {

--- a/frontend/apps/shell/next.config.js
+++ b/frontend/apps/shell/next.config.js
@@ -34,6 +34,9 @@ module.exports = withVanillaExtract({
     ];
   },
   webpack(config, options) {
+    config.infrastructureLogging = {
+      level: 'error',
+    };
     if (!options.isServer) {
       config.plugins.push(
         new NextFederationPlugin({

--- a/frontend/apps/user/next.config.js
+++ b/frontend/apps/user/next.config.js
@@ -35,6 +35,9 @@ module.exports = withVanillaExtract({
     ];
   },
   webpack(config, options) {
+    config.infrastructureLogging = {
+      level: 'error',
+    };
     if (!options.isServer) {
       config.plugins.push(
         new NextFederationPlugin({


### PR DESCRIPTION
## 개요

- 웹팩이 캐싱 성공/실패 여부를 모두 로그를 찍는 현상이 있습니다. 빌드가 실패했을 때에만 에러 로그를 남기도록 설정을 수정합니다.

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).