### PR TITLE
Fix: amadda/KAFKA 모듈의 컨슈머 인스턴스가 싱글톤으로 생성되도록 수정

### DIFF
--- a/frontend/_libs/kafka/kafka_notice.ts
+++ b/frontend/_libs/kafka/kafka_notice.ts
@@ -21,8 +21,10 @@ export const KAFKA_NOTICE = async () => {
     await notice_consumer.subscribe({
       topics: [friendRequest, friendAccept, scheduleAssigned, scheduleUpdate, scheduleNotification],
     });
-    return notice_consumer;
   } catch (err) {
+    //TODO: 중복 구독 처리
     Sentry.captureException(err);
+  } finally {
+    return notice_consumer;
   }
 };

--- a/frontend/_libs/kafka/kafka_notice.ts
+++ b/frontend/_libs/kafka/kafka_notice.ts
@@ -12,19 +12,12 @@ const kafka = new Kafka({
   brokers: [process.env.KAFKA_BROKER_1, process.env.KAFKA_BROKER_2, process.env.KAFKA_BROKER_3] as string[],
 });
 
-const notice_consumer = kafka.consumer({ groupId: groupId });
-export const KAFKA_NOTICE = async () => {
-  console.log('kafka-start subscribe');
-
-  try {
-    await notice_consumer.connect();
-    await notice_consumer.subscribe({
-      topics: [friendRequest, friendAccept, scheduleAssigned, scheduleUpdate, scheduleNotification],
-    });
-  } catch (err) {
-    //TODO: 중복 구독 처리
-    Sentry.captureException(err);
-  } finally {
-    return notice_consumer;
-  }
-};
+export const KAFKA_NOTICE = kafka.consumer({ groupId: groupId });
+try {
+  KAFKA_NOTICE.connect();
+  KAFKA_NOTICE.subscribe({
+    topics: [friendRequest, friendAccept, scheduleAssigned, scheduleUpdate, scheduleNotification],
+  });
+} catch (err) {
+  Sentry.captureException(err);
+}

--- a/frontend/_libs/kafka/kafka_schedule.ts
+++ b/frontend/_libs/kafka/kafka_schedule.ts
@@ -17,8 +17,10 @@ export const KAFKA_SCHEDULE = async () => {
     await schedule_consumer.subscribe({
       topics: [scheduleReload],
     });
-    return schedule_consumer;
   } catch (err) {
+    //TODO: 중복 구독 처리
     Sentry.captureException(err);
+  } finally {
+    return schedule_consumer;
   }
 };

--- a/frontend/_libs/kafka/kafka_schedule.ts
+++ b/frontend/_libs/kafka/kafka_schedule.ts
@@ -9,18 +9,13 @@ const kafka = new Kafka({
   brokers: [process.env.KAFKA_BROKER_1, process.env.KAFKA_BROKER_2, process.env.KAFKA_BROKER_3] as string[],
 });
 
-const schedule_consumer = kafka.consumer({ groupId: groupId });
-export const KAFKA_SCHEDULE = async () => {
-  console.log('kafka-start subscribe');
-  try {
-    await schedule_consumer.connect();
-    await schedule_consumer.subscribe({
-      topics: [scheduleReload],
-    });
-  } catch (err) {
-    //TODO: 중복 구독 처리
-    Sentry.captureException(err);
-  } finally {
-    return schedule_consumer;
-  }
-};
+export const KAFKA_SCHEDULE = kafka.consumer({ groupId: groupId });
+try {
+  KAFKA_SCHEDULE.connect();
+  KAFKA_SCHEDULE.subscribe({
+    topics: [scheduleReload],
+  });
+} catch (err) {
+  //TODO: 중복 구독 처리
+  Sentry.captureException(err);
+}

--- a/frontend/apps/notice/pages/api/event.ts
+++ b/frontend/apps/notice/pages/api/event.ts
@@ -7,24 +7,23 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
   res.setHeader('Content-Type', 'text/event-stream');
   res.setHeader('Cache-Control', 'no-cache');
   res.setHeader('Connection', 'keep-alive');
-
+  const consumer = await KAFKA_NOTICE();
   try {
-    const consumer = await KAFKA_NOTICE();
-
-    consumer &&
-      (await consumer.run({
-        eachMessage: async ({ topic, partition, message }) => {
-          const payload = message.value && message.value.toString();
-          res.write(`data: ${payload}\n\n`);
-        },
-      }));
+    await consumer.run({
+      eachMessage: async ({ topic, partition, message }) => {
+        const payload = message.value && message.value.toString();
+        res.write(`data: ${payload}\n\n`);
+      },
+    });
 
     req.on('close', () => {
       console.log('Client disconnected');
+      consumer.disconnect();
       return res.end();
     });
   } catch (err) {
     Sentry.captureException(err);
+    await consumer.disconnect();
     return res.status(500).json({ data: 'internal server error' });
   }
 }

--- a/frontend/apps/notice/pages/api/event.ts
+++ b/frontend/apps/notice/pages/api/event.ts
@@ -7,23 +7,19 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
   res.setHeader('Content-Type', 'text/event-stream');
   res.setHeader('Cache-Control', 'no-cache');
   res.setHeader('Connection', 'keep-alive');
-  const consumer = await KAFKA_NOTICE();
+  const consumer = KAFKA_NOTICE;
   try {
     await consumer.run({
       eachMessage: async ({ topic, partition, message }) => {
         const payload = message.value && message.value.toString();
-        res.write(`data: ${payload}\n\n`);
+        res.write(`${payload}`);
       },
     });
-
     req.on('close', () => {
-      console.log('Client disconnected');
-      consumer.disconnect();
       return res.end();
     });
   } catch (err) {
     Sentry.captureException(err);
-    await consumer.disconnect();
     return res.status(500).json({ data: 'internal server error' });
   }
 }

--- a/frontend/apps/schedule/pages/api/event.ts
+++ b/frontend/apps/schedule/pages/api/event.ts
@@ -7,23 +7,22 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
   res.setHeader('Content-Type', 'text/event-stream');
   res.setHeader('Cache-Control', 'no-cache');
   res.setHeader('Connection', 'keep-alive');
-
+  const consumer = await KAFKA_SCHEDULE();
   try {
-    const consumer = await KAFKA_SCHEDULE();
-
-    consumer &&
-      (await consumer.run({
-        eachMessage: async ({ topic, partition, message }) => {
-          res.status(204);
-        },
-      }));
+    await consumer.run({
+      eachMessage: async ({ topic, partition, message }) => {
+        res.status(204);
+      },
+    });
 
     req.on('close', () => {
       console.log('Client disconnected');
+      consumer.disconnect();
       return res.end();
     });
   } catch (err) {
     Sentry.captureException(err);
+    await consumer.disconnect();
     return res.status(500).json({ data: 'internal server error' });
   }
 }

--- a/frontend/apps/schedule/pages/api/event.ts
+++ b/frontend/apps/schedule/pages/api/event.ts
@@ -7,7 +7,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
   res.setHeader('Content-Type', 'text/event-stream');
   res.setHeader('Cache-Control', 'no-cache');
   res.setHeader('Connection', 'keep-alive');
-  const consumer = await KAFKA_SCHEDULE();
+  const consumer = KAFKA_SCHEDULE;
   try {
     await consumer.run({
       eachMessage: async ({ topic, partition, message }) => {
@@ -16,13 +16,10 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
     });
 
     req.on('close', () => {
-      console.log('Client disconnected');
-      consumer.disconnect();
       return res.end();
     });
   } catch (err) {
     Sentry.captureException(err);
-    await consumer.disconnect();
     return res.status(500).json({ data: 'internal server error' });
   }
 }


### PR DESCRIPTION
## 개요

- API 핸들러에서 함수를 호출해서 인스턴스를 리턴받도록 하는 패턴에서, 인스턴스 자체를 import하는 방식으로 변경했습니다. 지금 상황에서는 누군가 요청을 할 때마다 해당 함수가 실행되면서 인스턴스가 새로 만들어집니다.
- 중복 구독을 요청해도 카프카가 꺼지거나 하는 문제가 벌어지지는 않지만, Next.js 서버가 카프카에 구독을 한 상태에서 계속해서 구독을 요청하는 상황이 잘못된 것이기 때문에 이를 수정합니다.

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).