### PR TITLE
Refactor: 알림 리스트 data fetching 로직 리팩토링

### DIFF
--- a/frontend/apps/notice/components/Notice/NoticeFrame.tsx
+++ b/frontend/apps/notice/components/Notice/NoticeFrame.tsx
@@ -1,13 +1,10 @@
-import React from 'react';
-import { useEffect } from 'react';
-import { ErrorBoundary, Flex, H3, List, Spacing } from '@amadda/external-temporal';
-import { AlarmReadResponse } from '@amadda/global-types';
+import React, { Suspense } from 'react';
+import { ErrorBoundary, Flex, H3, List, Loading, Spacing } from '@amadda/external-temporal';
 import { useGetNotice } from '@N/hooks/useGetNotice';
-import { useRouter } from 'next/router';
 import { Notice } from './Notice';
 
 export function NoticeFrame() {
-  const { noticeList, error } = useGetNotice();
+  const { noticeList } = useGetNotice();
 
   return (
     <div>
@@ -16,11 +13,14 @@ export function NoticeFrame() {
         <Spacing dir="v" size="0.25" />
         <ErrorBoundary message="알람을 가져오는 데 실패했어요.">
           <List.Ul>
-            {noticeList.map(n => (
-              <List.Li key={n.alarmSeq + n.content}>
-                <Notice {...n} />
-              </List.Li>
-            ))}
+            <Suspense fallback={<Loading />}>
+              {noticeList &&
+                noticeList.map(n => (
+                  <List.Li key={n.alarmSeq + n.content}>
+                    <Notice {...n} />
+                  </List.Li>
+                ))}
+            </Suspense>
           </List.Ul>
         </ErrorBoundary>
       </Flex>

--- a/frontend/apps/notice/hooks/useGetNotice.ts
+++ b/frontend/apps/notice/hooks/useGetNotice.ts
@@ -1,22 +1,11 @@
 import { clientFetch } from '@amadda/fetch';
 import { AlarmReadResponse } from '@amadda/global-types';
-import { useEffect, useState } from 'react';
 import useSWR from 'swr';
-import useSWRSubscription from 'swr/subscription';
 
 const fetcher = () => clientFetch.get<Array<AlarmReadResponse>>(`${process.env.NEXT_PUBLIC_NOTICE}/api/alarm`);
 
 export function useGetNotice() {
-  const [noticeList, setNoticeList] = useState<Array<AlarmReadResponse>>([]);
-  const { data, error } = useSWR<Array<AlarmReadResponse>>('/api/alarm', fetcher);
-
-  const { data: sub, error: eventSrcError } = useSWRSubscription('/notice/event', (key, { next }) => {
-    const eventSource = new EventSource(`${process.env.NEXT_PUBLIC_NOTICE}/api/eventsrc`);
-    eventSource.onmessage = async (e: MessageEvent) => next(null, e.data);
-    eventSource.onerror = async (error: Event) => next(error);
-    return () => eventSource.close();
-  });
-  data && setNoticeList(data);
-  sub && setNoticeList(data ? [...data, sub] : [sub]);
-  return { noticeList, setNoticeList, error: error || eventSrcError };
+  const { data, error, isLoading } = useSWR<Array<AlarmReadResponse>>('/api/alarm', fetcher);
+  //TODO: 데이터 출처가 eventsource, api 두 곳일 때 SWR를 어떻게 사용할 수 있을지
+  return { noticeList: data, error, isLoading };
 }

--- a/frontend/apps/shell/components/Header/Header.tsx
+++ b/frontend/apps/shell/components/Header/Header.tsx
@@ -1,33 +1,14 @@
 import React from 'react';
-import { useEffect, useState } from 'react';
 import { Flex, Spacing } from '@amadda/external-temporal';
 import { BASE } from './Header.css';
 import { Menu } from './Menu';
-import type { AlarmReadResponse } from '@amadda/global-types';
+
 import { useRouter } from 'next/router';
+import { useSubscribeNotice } from '@SH/hooks/useSubscribeNotice';
 
 export function Header() {
-  const [notice, setNotice] = useState(false);
   const router = useRouter();
-
-  useEffect(() => {
-    const eventSource = new EventSource(`${process.env.NEXT_PUBLIC_NOTICE}/api/event`);
-
-    eventSource.onmessage = async (e: MessageEvent) => {
-      const data: AlarmReadResponse = JSON.parse(await e.data);
-      if (!data?.isRead) setNotice(true);
-    };
-
-    eventSource.onerror = async (error: Event) => {
-      setNotice(false);
-      console.error('EventSource failed:', error);
-      eventSource.close();
-    };
-
-    return () => {
-      eventSource.close();
-    };
-  }, [router.basePath]);
+  const { data, error } = useSubscribeNotice();
   return (
     <div className={BASE}>
       <Flex justifyContents="spaceBetween">
@@ -49,9 +30,8 @@ export function Header() {
             }}
           /> */}
             <Menu
-              iconType={notice ? 'noti' : 'noti_red'}
+              iconType={data ? 'noti' : 'noti_red'}
               onClick={() => {
-                setNotice(false);
                 router.push(`${process.env.NEXT_PUBLIC_SHELL}/notice`);
               }}
             />

--- a/frontend/apps/shell/hooks/useSubscribeNotice.ts
+++ b/frontend/apps/shell/hooks/useSubscribeNotice.ts
@@ -1,0 +1,12 @@
+import useSWRSubscription from 'swr/subscription';
+
+export function useSubscribeNotice() {
+  const { data, error } = useSWRSubscription('/notice/event', (key, { next }) => {
+    const eventSource = new EventSource(`${process.env.NEXT_PUBLIC_NOTICE}/api/eventsrc`);
+    eventSource.onmessage = async (e: MessageEvent) => next(null, e.data);
+    eventSource.onerror = async (error: Event) => next(error);
+    return () => eventSource.close();
+  });
+
+  return { data, error };
+}


### PR DESCRIPTION
# 문제점

- 알림 리스트는 `KAFKA`가 주는 실시간 메시지와, `Spring` 서버 두 곳의 데이터를 받습니다.
- 해당 상태의 초기값은 Spring 서버의 알림 리스트이지만, 이후에는 KAFKA Subscription을 통해 실시간 메시지를 제공받습니다.
- 해당 로직으로 인한 문제는 하나의 상태가 두 가지 출처에서 업데이트된다는 것인데, 두 가지 출처라고 하지만 초기값을 제외한 소스는 실시간 데이터 하나이므로 문제가 되는 상황은 아닌 것 같습니다.
- 다만 SWR이 API 데이터를 refetch하거나 하면 문제가 생길 수 있는데요, 해당 부분에 대한 컨트롤과 상태 동기화 문제를 주의깊게 생각해보고자 해당 로직을 다시 생각해보려고 합니다.

현재는 KAFKA 시그널을 받았을 때 해당 데이터를 상태에 그대로 추가합니다. 구현이 쉽지만 안정성이 떨어지고 중복된 데이터가 쌓이는 등 예외 처리가 까다로워집니다. 초기값으로 API Call을 받기 때문에 데이터 자체의 무결성은 보장되지만, eventsource 연결 상황과 SWR Call 시점에 따라 사용자가 중복된 데이터를 수신하거나 하는 일이 생길 수 있습니다.

우선 지금으로서의 대안은
0. API 호출이 성공했을 때 eventsrc 연결을 시도하도록 해 초기값 충돌 같은 문제를 방지합니다.
1. KAFKA 시그널을 받을 때 API를 `mutate`만 시킴으로써 단일 출처로 만듭니다. - 이 방법은 kafka 데이터를 받으면서도 api 호출을 계속하므로 비효율적인 통신이 계속되는 방법이지만, 데이터의 안정성과 중복 처리 문제 등을 한 번에 해결할 수 있습니다.

정도가 생각납니다만, 솔직히 방법 1 또한 현재와 동일하게 eventsource 연결 상태에 따라 알림을 바로 수신하지 못하는 문제가 있습니다. 즉 불필요한 api call만 계속해서 일어나는 느낌인데, 이에 대한 다른 대안으로,

2. 현재의 구현 + SWR이 알림 데이터를 일정 주기마다 polling하도록 해 현재 데이터를 덮어써서 누락된 업데이트를 복구해주는 것이 적절한 대안인가는 또 생각해봐야 할 일인 것 같습니다. (그래도 현재로서 좀 괜찮은 타협안이 아닌가 싶기는 합니다)





## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).